### PR TITLE
[SMT] Add "--incremental" flag to cvc5 to avoid crash

### DIFF
--- a/patronus/src/smt/solver.rs
+++ b/patronus/src/smt/solver.rs
@@ -422,7 +422,7 @@ pub const Z3: SmtLibSolver = SmtLibSolver {
 
 pub const CVC5: SmtLibSolver = SmtLibSolver {
     name: "cvc5",
-    args: &[],
+    args: &["--incremental"],
     options: &[],
     supports_uf: true,
     supports_check_assuming: true,

--- a/tools/bmc/src/main.rs
+++ b/tools/bmc/src/main.rs
@@ -24,6 +24,8 @@ struct Args {
         help = "the SMT solver to use"
     )]
     solver: SolverChoice,
+    #[arg(short, long, default_value = "25")]
+    kmax: u64,
     #[arg(short, long)]
     verbose: bool,
     #[arg(short, long)]
@@ -58,7 +60,7 @@ fn main() {
         println!();
         println!();
     }
-    let k_max = 25;
+    let k_max = args.kmax;
     let check_constraints = true;
     let check_bad_states_individually = false;
     let solver = match args.solver {


### PR DESCRIPTION
I tried running the cvc5 backend and ran into:
```
Running `<file_name>.btor2 --solver cvc5`

thread 'main' (95116) panicked at tools/bmc/src/main.rs:89:6:
called `Result::unwrap()` on an `Err` value: FromSolver("cvc5", "\"Cannot make multiple queries unless incremental solving is enabled
```

It seems that cvc5 was the only backend that didn't have incremental solving enabled so I added that option to the solver and now it runs.