### PR TITLE
Factored out init frame into `BasePdr` struct field

### DIFF
--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -244,7 +244,7 @@ fn query(
 /// **Representation Invariant**: `frames.len() > 0`
 struct BasePdr {
     /// Initial frame
-    init_frame: Cube,
+    init_frame: ExprRef,
 
     /// Frame trace containing frames with blocked cubes
     frames: Vec<Vec<Cube>>,
@@ -256,7 +256,12 @@ impl BasePdr {
     /// # Precondition
     /// State variables in transition system need to be stepped
     /// at two adjacent steps
-    fn init(ctx: &mut Context, sys: &TransitionSystem) -> Self {
+    fn init(
+        ctx: &mut Context,
+        smt_ctx: &mut impl SolverContext,
+        enc: &impl TransitionSystemEncoding,
+        sys: &TransitionSystem,
+    ) -> Result<Self> {
         let mut init_cube = Cube::tru();
 
         // Get all initial states from the system and create equalities between symbol
@@ -268,42 +273,46 @@ impl BasePdr {
             }
         }
 
-        Self {
-            init_frame: init_cube,
+        // Initial frame activation literal
+        let init_act = ctx.bv_symbol("act_0", 1);
+
+        // Create act_0 => init_cube, where init_cube is stepped to the before step
+        let init_expr = init_cube.to_expr(ctx);
+        let init_expr = expr_at_step(ctx, enc, init_expr, FROM_STEP);
+        let imp = ctx.implies(init_act, init_expr);
+
+        // Permanently assert implication in solver
+        smt_ctx.declare_const(ctx, init_act)?;
+        smt_ctx.assert(ctx, imp)?;
+
+        Ok(Self {
+            init_frame: init_act,
             frames: vec![vec![]], // Keep index consistency by adding dummy frame in place of init
-        }
-    }
-
-    /// # Returns
-    /// Cube expression representing initial states covered by initial frame
-    fn init_frame_assumptions(&self, ctx: &mut Context) -> ExprRef {
-        self.init_frame.clone().to_expr(ctx)
-    }
-
-    /// # Preconditions
-    /// `frame` > 0 /\ `frame` < `self.frames.len()`
-    ///
-    /// # Returns
-    /// Clause representing non-init frame
-    fn non_init_frame_assumptions(&self, ctx: &mut Context, frame: FrameId) -> ExprRef {
-        assert!(frame > 0 && frame < self.frames.len());
-
-        // Else, just get conjunction of negated cubes (clauses)
-        self.frames[frame].iter().fold(ctx.get_true(), |acc, cube| {
-            let clause = cube.negate(ctx);
-            ctx.and(acc, clause)
         })
     }
 
     /// # Returns
     /// SMT expression representing over-approximation of states reachable in `frame` steps
-    /// (i.e. state space of `frame`-th frame)
-    fn frame_assumptions(&self, ctx: &mut Context, frame: FrameId) -> ExprRef {
+    /// (i.e. state space of `frame`-th frame), stepped at pre-transition step
+    fn frame_assumptions(
+        &self,
+        ctx: &mut Context,
+        enc: &impl TransitionSystemEncoding,
+        frame: FrameId,
+    ) -> ExprRef {
         if frame == 0 {
-            // Special case: init frame
-            self.init_frame_assumptions(ctx)
+            // Special case: init frame is just activation literal for initial states
+            self.init_frame
         } else {
-            self.non_init_frame_assumptions(ctx, frame)
+            assert!(frame < self.frames.len());
+
+            // Else, just get conjunction of negated cubes (clauses)
+            let expr = self.frames[frame].iter().fold(ctx.get_true(), |acc, cube| {
+                let clause = cube.negate(ctx);
+                ctx.and(acc, clause)
+            });
+
+            expr_at_step(ctx, enc, expr, FROM_STEP)
         }
     }
 
@@ -322,8 +331,8 @@ impl BasePdr {
         let mut assumptions = Vec::new();
 
         // Get frame assumption
-        let frame_assumption = self.frame_assumptions(ctx, cube.frame - 1);
-        assumptions.push(expr_at_step(ctx, enc, frame_assumption, FROM_STEP));
+        let frame_assumption = self.frame_assumptions(ctx, enc, cube.frame - 1);
+        assumptions.push(frame_assumption);
 
         // Next step cube
         let cube_expr = cube.cube.to_expr(ctx);
@@ -391,11 +400,10 @@ impl BasePdr {
             .fold(ctx.get_false(), |acc, &b| ctx.or(acc, b));
 
         // Get frame assumptions for frontier frame
-        let front_assumption = self.frame_assumptions(ctx, front);
-        let front_cur = expr_at_step(ctx, enc, front_assumption, FROM_STEP);
+        let front_assumption = self.frame_assumptions(ctx, enc, front);
 
         // Run query SAT?[R_N /\ \neg P]
-        match query(ctx, smt_ctx, sys, enc, vec![front_cur, bad_expr])? {
+        match query(ctx, smt_ctx, sys, enc, vec![front_assumption, bad_expr])? {
             (CheckSatResponse::Sat, Some(cube)) => {
                 // Safety property violation found: return witness cube
                 Ok(Some(cube))
@@ -542,7 +550,7 @@ pub fn pdr(
     enc.unroll(ctx, smt_ctx)?;
 
     // Initialize PDR
-    let mut state = BasePdr::init(ctx, sys);
+    let mut state = BasePdr::init(ctx, smt_ctx, &enc, sys)?;
 
     // PDR loop
     while state.frontier() <= MAX_FRAMES {

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -243,6 +243,9 @@ fn query(
 ///
 /// **Representation Invariant**: `frames.len() > 0`
 struct BasePdr {
+    /// Initial frame
+    init_frame: Cube,
+
     /// Frame trace containing frames with blocked cubes
     frames: Vec<Vec<Cube>>,
 }
@@ -266,25 +269,41 @@ impl BasePdr {
         }
 
         Self {
-            frames: vec![vec![init_cube]],
+            init_frame: init_cube,
+            frames: vec![vec![]], // Keep index consistency by adding dummy frame in place of init
         }
     }
 
     /// # Returns
-    /// * Clause representing non-init frame
-    /// * Cube representing init frame
-    fn frame_assumptions(&self, ctx: &mut Context, frame: FrameId) -> ExprRef {
-        assert!(frame < self.frames.len());
+    /// Cube expression representing initial states covered by initial frame
+    fn init_frame_assumptions(&self, ctx: &mut Context) -> ExprRef {
+        self.init_frame.clone().to_expr(ctx)
+    }
 
+    /// # Preconditions
+    /// `frame` > 0 /\ `frame` < `self.frames.len()`
+    ///
+    /// # Returns
+    /// Clause representing non-init frame
+    fn non_init_frame_assumptions(&self, ctx: &mut Context, frame: FrameId) -> ExprRef {
+        assert!(frame > 0 && frame < self.frames.len());
+
+        // Else, just get conjunction of negated cubes (clauses)
+        self.frames[frame].iter().fold(ctx.get_true(), |acc, cube| {
+            let clause = cube.negate(ctx);
+            ctx.and(acc, clause)
+        })
+    }
+
+    /// # Returns
+    /// SMT expression representing over-approximation of states reachable in `frame` steps
+    /// (i.e. state space of `frame`-th frame)
+    fn frame_assumptions(&self, ctx: &mut Context, frame: FrameId) -> ExprRef {
         if frame == 0 {
-            // Special case: init frame is just conjunction
-            self.frames[0][0].to_expr(ctx)
+            // Special case: init frame
+            self.init_frame_assumptions(ctx)
         } else {
-            // Else, just get conjunction of negated cubes (clauses)
-            self.frames[frame].iter().fold(ctx.get_true(), |acc, cube| {
-                let clause = cube.negate(ctx);
-                ctx.and(acc, clause)
-            })
+            self.non_init_frame_assumptions(ctx, frame)
         }
     }
 


### PR DESCRIPTION
# Changes
- Factored out init frame into its own field in `BasePdr`
- Factored old `frame_assumptions` function into `init_frame_assumptions` and `non_init_frame_assumptions` to return expressions representing the init frame ($\mathbf{R}_0$) and  non-init frames ($\mathbf{R}_i$ where $i > 0$), respectively
- Reimplemented `frame_assumptions` as a helper function to call `init_frame_assumptions` and `non_init_frame_assumptions`

# Tests
All regression tests pass

# Future Plans
- Try to replace current `usize` scheme for `FrameId` into an `enum` that includes specific identifiers for the init frame and infinite frame to prevent "magic indices" for these special frames