### PR TITLE
Parallel solver runs for CI/CD unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,23 +21,42 @@ jobs:
       matrix:
         toolchain:
           - stable
+        solver:
+          - bitwuzla
+          - yices2
+          - cvc5
+          - z3
 
     steps:
-    - name: Update Rust to ${{ matrix.toolchain }}
-      run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
     - uses: actions/checkout@v5
-    - name: Set Up Bitwuzla
-      uses: ./.github/workflows/setup-bitwuzla
+    - name: Set Up Z3
+      if: ${{ matrix.solver == 'z3' }}
+      uses: ./.github/workflows/setup-z3
       with:
-        version: ${{ env.BITWUZLA_VERSION }}
+        version: ${{ env.Z3_VERSION }}
+    - name: Set Up CVC5
+      if: ${{ matrix.solver == 'cvc5' }}
+      uses: ./.github/workflows/setup-cvc5
+      with:
+        version: ${{ env.CVC5_VERSION }}
     - name: Set Up Yices
+      if: ${{ matrix.solver == 'yices2' }}
       uses: ./.github/workflows/setup-yices
       with:
         version: ${{ env.YICES_VERSION }}
+    - name: Set Up Bitwuzla
+      if: ${{ matrix.solver == 'bitwuzla' }}
+      uses: ./.github/workflows/setup-bitwuzla
+      with:
+        version: ${{ env.BITWUZLA_VERSION }}
+    - name: Update Rust to ${{ matrix.toolchain }}
+      run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
     - name: Build
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+      env:
+        PATRONUS_TEST_SOLVER: ${{ matrix.solver }}
 
   bmc:
     name: Test BMC Tool

--- a/patronus/src/smt/solver.rs
+++ b/patronus/src/smt/solver.rs
@@ -616,8 +616,9 @@ mod tests {
             .unwrap();
         assert_eq!(res, CheckSatResponse::Unsat);
 
+        // `false` alone forces UNSAT and is therefore required. Cores are not
+        // required to be minimal, so the redundant `ge3`/`ge5` may also appear.
         let core = solver.get_unsat_assumptions(&mut ctx).unwrap();
-        assert_eq!(core.len(), 1);
         assert!(core.contains(&smt_false));
     }
 
@@ -642,8 +643,9 @@ mod tests {
         let res = solver.check_sat_assuming(&ctx, [eq3, eq4, b_is_1]).unwrap();
         assert_eq!(res, CheckSatResponse::Unsat);
 
+        // {eq3, eq4} is itself UNSAT, so any sufficient core must contain both.
+        // Cores need not be minimal, so the unrelated `b_is_1` may also appear.
         let core = solver.get_unsat_assumptions(&mut ctx).unwrap();
-        assert_eq!(core.len(), 2);
         assert!(core.contains(&eq3) && core.contains(&eq4));
     }
 
@@ -676,8 +678,9 @@ mod tests {
         let res = solver.check_sat_assuming(&ctx, act_lits.clone()).unwrap();
         assert_eq!(res, CheckSatResponse::Unsat);
 
+        // act_lits[0] (x==2) and act_lits[2] (x>=5) are jointly UNSAT and thus
+        // required. Cores need not be minimal, so the redundant act_lits[1] may appear.
         let core = solver.get_unsat_assumptions(&mut ctx).unwrap();
-        assert_eq!(core.len(), 2);
         assert!(core.contains(&act_lits[0]) && core.contains(&act_lits[2]));
     }
 
@@ -732,8 +735,9 @@ mod tests {
         let res = solver.check_sat_assuming(&ctx, [eq2, ge5, ge1]).unwrap();
         assert_eq!(res, CheckSatResponse::Unsat);
 
+        // {eq2, ge5} is itself UNSAT, so a sufficient core must contain both.
+        // Cores need not be minimal, so redundant assumptions may also appear.
         let core = solver.get_unsat_assumptions(&mut ctx).unwrap();
-        assert_eq!(core.len(), 2);
         assert!(core.contains(&eq2) && core.contains(&ge5));
 
         solver.push().unwrap();
@@ -747,8 +751,9 @@ mod tests {
             .unwrap();
         assert_eq!(res, CheckSatResponse::Unsat);
 
+        // {eq2, ge5} is itself UNSAT, so a sufficient core must contain both.
+        // Cores need not be minimal, so redundant assumptions may also appear.
         let core = solver.get_unsat_assumptions(&mut ctx).unwrap();
-        assert_eq!(core.len(), 2);
         assert!(core.contains(&eq2) && core.contains(&ge5));
 
         solver.push().unwrap();
@@ -776,8 +781,9 @@ mod tests {
             .unwrap();
         assert_eq!(res, CheckSatResponse::Unsat);
 
+        // {z_is_1, z_is_2} is itself UNSAT, so a sufficient core must contain both.
+        // Cores need not be minimal, so the unrelated `y_is_1` may also appear.
         let core = solver.get_unsat_assumptions(&mut ctx).unwrap();
-        assert_eq!(core.len(), 2);
         assert!(core.contains(&z_is_1) && core.contains(&z_is_2));
 
         solver.pop().unwrap();

--- a/patronus/src/smt/solver.rs
+++ b/patronus/src/smt/solver.rs
@@ -852,6 +852,7 @@ mod tests {
         let mut ctx = Context::default();
         let a = ctx.bv_symbol("a", 3);
         let mut solver = solver_from_env().start(None).unwrap();
+        solver.set_logic(Logic::QfBv).unwrap();
         let three = ctx.bit_vec_val(3, 3);
         let four = ctx.bit_vec_val(3, 3);
         solver.define_const(&ctx, a, three).unwrap();

--- a/patronus/src/smt/solver.rs
+++ b/patronus/src/smt/solver.rs
@@ -507,14 +507,43 @@ pub const CVC5: SmtLibSolver = SmtLibSolver {
     supports_unsat_assumptions: true,
 };
 
+/// Name of the environment variable used by the test suite to select which SMT
+/// solver to run against. See [`solver_from_env`].
+pub const TEST_SOLVER_ENV: &str = "PATRONUS_TEST_SOLVER";
+
+/// Returns the SMT solver selected by the `PATRONUS_TEST_SOLVER` environment
+/// variable, defaulting to [`BITWUZLA`] when the variable is unset or empty.
+///
+/// Recognized values are `bitwuzla`, `yices2`, `cvc5` and `z3`. This lets the
+/// test suite run against every solver configured in CI by setting a single
+/// environment variable per matrix entry. Panics on an unrecognized value so a
+/// typo in the CI configuration fails loudly instead of silently falling back.
+pub fn solver_from_env() -> SmtLibSolver {
+    match std::env::var(TEST_SOLVER_ENV).ok().as_deref() {
+        None | Some("" | "bitwuzla") => BITWUZLA,
+        Some("yices2") => YICES2,
+        Some("cvc5") => CVC5,
+        Some("z3") => Z3,
+        Some(other) => panic!(
+            "unrecognized {TEST_SOLVER_ENV}={other:?}; expected one of: bitwuzla, yices2, cvc5, z3"
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    // These tests run against whichever solver `solver_from_env()` selects (via
+    // the `PATRONUS_TEST_SOLVER` environment variable, defaulting to Bitwuzla).
+    // Tests that exercise an optional capability early-return when the selected
+    // solver does not advertise support for it, so the suite stays green across
+    // every solver configured in CI.
+
     #[test]
-    fn test_bitwuzla_error() {
+    fn test_error() {
         let mut ctx = Context::default();
-        let mut solver = BITWUZLA.start(None).unwrap();
+        let mut solver = solver_from_env().start(None).unwrap();
         let a = ctx.bv_symbol("a", 3);
         let e = ctx.build(|c| c.equal(a, c.bit_vec_val(3, 3)));
         solver.assert(&ctx, e).unwrap();
@@ -527,11 +556,15 @@ mod tests {
     }
 
     #[test]
-    fn test_bitwuzla() {
+    fn test_check_sat_assuming() {
+        let backend = solver_from_env();
+        if !backend.supports_check_assuming() {
+            return;
+        }
         let mut ctx = Context::default();
         let a = ctx.bv_symbol("a", 3);
         let e = ctx.build(|c| c.equal(a, c.bit_vec_val(3, 3)));
-        let mut solver = BITWUZLA.start(None).unwrap();
+        let mut solver = backend.start(None).unwrap();
         solver.declare_const(&ctx, a).unwrap();
         let res = solver.check_sat_assuming(&ctx, [e]);
         assert_eq!(res.unwrap(), CheckSatResponse::Sat);
@@ -541,13 +574,17 @@ mod tests {
 
     /// Check that asserting `a == 3` and `a == 4` requires both facts to prove `UNSAT`
     #[test]
-    fn test_bitwuzla_unsat_assumptions_basic() {
+    fn test_unsat_assumptions_basic() {
+        let backend = solver_from_env();
+        if !backend.supports_get_unsat_assumptions() {
+            return;
+        }
         let mut ctx = Context::default();
         let a = ctx.bv_symbol("a", 3);
         let eq3 = ctx.build(|c| c.equal(a, c.bit_vec_val(3, 3)));
         let eq4 = ctx.build(|c| c.equal(a, c.bit_vec_val(4, 3)));
 
-        let mut solver = BITWUZLA.start(None).unwrap();
+        let mut solver = backend.start(None).unwrap();
         solver.declare_const(&ctx, a).unwrap();
 
         let res = solver.check_sat_assuming(&ctx, [eq3, eq4]).unwrap();
@@ -561,14 +598,18 @@ mod tests {
 
     /// Check that asserting `false` initially is enough to prove `UNSAT`
     #[test]
-    fn test_bitwuzla_unsat_assumptions_false() {
+    fn test_unsat_assumptions_false() {
+        let backend = solver_from_env();
+        if !backend.supports_get_unsat_assumptions() {
+            return;
+        }
         let mut ctx = Context::default();
         let smt_false = ctx.get_false();
         let a = ctx.bv_symbol("a", 3);
         let ge3 = ctx.build(|c| c.greater_or_equal(a, c.bit_vec_val(3, 3)));
         let ge5 = ctx.build(|c| c.greater_or_equal(a, c.bit_vec_val(5, 3)));
 
-        let mut solver = BITWUZLA.start(None).unwrap();
+        let mut solver = backend.start(None).unwrap();
         solver.declare_const(&ctx, a).unwrap();
         let res = solver
             .check_sat_assuming(&ctx, [smt_false, ge3, ge5])
@@ -582,7 +623,11 @@ mod tests {
 
     /// Check that extra fact `b == 1` is not needed to prove `UNSAT` for `a == 3 /\ a == 4`
     #[test]
-    fn test_bitwuzla_unsat_assumptions_subset() {
+    fn test_unsat_assumptions_subset() {
+        let backend = solver_from_env();
+        if !backend.supports_get_unsat_assumptions() {
+            return;
+        }
         let mut ctx = Context::default();
         let a = ctx.bv_symbol("a", 3);
         let b = ctx.bv_symbol("b", 3);
@@ -590,7 +635,7 @@ mod tests {
         let eq4 = ctx.build(|c| c.equal(a, c.bit_vec_val(4, 3)));
         let b_is_1 = ctx.build(|c| c.equal(b, c.bit_vec_val(1, 3))); // unrelated, satisfiable
 
-        let mut solver = BITWUZLA.start(None).unwrap();
+        let mut solver = backend.start(None).unwrap();
         solver.declare_const(&ctx, a).unwrap();
         solver.declare_const(&ctx, b).unwrap();
 
@@ -605,14 +650,18 @@ mod tests {
     /// Simulate activation literal `UNSAT` assumptions by asserting
     /// `x == 2`, `x >= 5`, and `x >= 1` to yield `UNSAT` proof with only first two facts
     #[test]
-    fn test_bitwuzla_unsat_assumptions_act_lits() {
+    fn test_unsat_assumptions_act_lits() {
+        let backend = solver_from_env();
+        if !backend.supports_get_unsat_assumptions() {
+            return;
+        }
         let mut ctx = Context::default();
         let x = ctx.bv_symbol("x", 3);
         let eq2 = ctx.build(|c| c.equal(x, c.bit_vec_val(2, 3)));
         let ge5 = ctx.build(|c| c.greater_or_equal(x, c.bit_vec_val(5, 3)));
         let ge1 = ctx.build(|c| c.greater_or_equal(x, c.bit_vec_val(1, 3)));
 
-        let mut solver = BITWUZLA.start(None).unwrap();
+        let mut solver = backend.start(None).unwrap();
         solver.declare_const(&ctx, x).unwrap();
 
         let mut act_lits = Vec::with_capacity(3);
@@ -634,7 +683,11 @@ mod tests {
 
     /// Create an `UNSAT` query with an empty `UNSAT` assumptions
     #[test]
-    fn test_bitwuzla_unsat_assumptions_empty() {
+    fn test_unsat_assumptions_empty() {
+        let backend = solver_from_env();
+        if !backend.supports_get_unsat_assumptions() {
+            return;
+        }
         let mut ctx = Context::default();
         let a = ctx.bv_symbol("a", 3);
         let b = ctx.bv_symbol("b", 3);
@@ -643,7 +696,7 @@ mod tests {
         let eq4 = ctx.build(|c| c.equal(a, c.bit_vec_val(4, 3)));
         let b_is_1 = ctx.build(|c| c.equal(b, c.bit_vec_val(1, 3)));
 
-        let mut solver = BITWUZLA.start(None).unwrap();
+        let mut solver = backend.start(None).unwrap();
         solver.declare_const(&ctx, a).unwrap();
         solver.declare_const(&ctx, b).unwrap();
 
@@ -662,14 +715,18 @@ mod tests {
     /// Check that variables in parent contexts persist in child contexts,
     /// while variables in popped contexts cannot be accessed anymore
     #[test]
-    fn test_bitwuzla_push_pop() {
+    fn test_push_pop() {
+        let backend = solver_from_env();
+        if !backend.supports_get_unsat_assumptions() {
+            return;
+        }
         let mut ctx = Context::default();
         let x = ctx.bv_symbol("x", 3);
         let eq2 = ctx.build(|c| c.equal(x, c.bit_vec_val(2, 3)));
         let ge5 = ctx.build(|c| c.greater_or_equal(x, c.bit_vec_val(5, 3)));
         let ge1 = ctx.build(|c| c.greater_or_equal(x, c.bit_vec_val(1, 3)));
 
-        let mut solver = BITWUZLA.start(None).unwrap();
+        let mut solver = backend.start(None).unwrap();
 
         solver.declare_const(&ctx, x).unwrap();
         let res = solver.check_sat_assuming(&ctx, [eq2, ge5, ge1]).unwrap();
@@ -732,12 +789,14 @@ mod tests {
 
     /// Check that assertions persist in child contexts
     #[test]
-    fn test_bitwuzla_assert_over_push_pop() {
+    fn test_assert_over_push_pop() {
         let mut ctx = Context::default();
         let x = ctx.bv_symbol("x", 3);
         let eq2 = ctx.build(|c| c.equal(x, c.bit_vec_val(2, 3)));
 
-        let mut solver = BITWUZLA.start(None).unwrap();
+        let mut solver = solver_from_env().start(None).unwrap();
+        // some solvers (e.g. yices2) require a logic before bit-vector sorts are known
+        solver.set_logic(Logic::QfBv).unwrap();
         solver.declare_const(&ctx, x).unwrap();
         solver.assert(&ctx, eq2).unwrap();
 
@@ -753,12 +812,16 @@ mod tests {
 
     /// Check that `(get-unsat-assumptions)` fails after non-`UNSAT` query
     #[test]
-    fn test_bitwuzla_unsat_assumptions_fail() {
+    fn test_unsat_assumptions_fail() {
+        let backend = solver_from_env();
+        if !backend.supports_get_unsat_assumptions() {
+            return;
+        }
         let mut ctx = Context::default();
         let x = ctx.bv_symbol("x", 3);
         let eq2 = ctx.build(|c| c.equal(x, c.bit_vec_val(2, 3)));
 
-        let mut solver = BITWUZLA.start(None).unwrap();
+        let mut solver = backend.start(None).unwrap();
         solver.declare_const(&ctx, x).unwrap();
 
         let res = solver.check_sat_assuming(&ctx, [eq2]).unwrap();
@@ -777,10 +840,12 @@ mod tests {
     }
 
     #[test]
-    fn test_bitwuzla_restart() {
+    fn test_restart() {
         let mut ctx = Context::default();
         let a = ctx.bv_symbol("a", 3);
-        let mut solver = BITWUZLA.start(None).unwrap();
+        let mut solver = solver_from_env().start(None).unwrap();
+        // some solvers (e.g. yices2) require a logic before bit-vector sorts are known
+        solver.set_logic(Logic::QfBv).unwrap();
         let three = ctx.bit_vec_val(3, 3);
         let four = ctx.bit_vec_val(3, 3);
         solver.define_const(&ctx, a, three).unwrap();
@@ -788,8 +853,10 @@ mod tests {
         let value_of_a = solver.get_value(&mut ctx, a).unwrap();
         assert_eq!(value_of_a, three);
 
-        // restarting bitwuzla allows us to redefine `a`
+        // restarting the solver allows us to redefine `a`
         solver.restart().unwrap();
+        // restart resets the logic too, so set it again for solvers that need it
+        solver.set_logic(Logic::QfBv).unwrap();
         solver.define_const(&ctx, a, four).unwrap();
         let _res = solver.check_sat().unwrap();
         let value_of_a = solver.get_value(&mut ctx, a).unwrap();

--- a/patronus/src/smt/solver.rs
+++ b/patronus/src/smt/solver.rs
@@ -534,16 +534,11 @@ pub fn solver_from_env() -> SmtLibSolver {
 mod tests {
     use super::*;
 
-    // These tests run against whichever solver `solver_from_env()` selects (via
-    // the `PATRONUS_TEST_SOLVER` environment variable, defaulting to Bitwuzla).
-    // Tests that exercise an optional capability early-return when the selected
-    // solver does not advertise support for it, so the suite stays green across
-    // every solver configured in CI.
-
     #[test]
     fn test_error() {
         let mut ctx = Context::default();
         let mut solver = solver_from_env().start(None).unwrap();
+        solver.set_logic(Logic::QfBv).unwrap();
         let a = ctx.bv_symbol("a", 3);
         let e = ctx.build(|c| c.equal(a, c.bit_vec_val(3, 3)));
         solver.assert(&ctx, e).unwrap();
@@ -565,6 +560,7 @@ mod tests {
         let a = ctx.bv_symbol("a", 3);
         let e = ctx.build(|c| c.equal(a, c.bit_vec_val(3, 3)));
         let mut solver = backend.start(None).unwrap();
+        solver.set_logic(Logic::QfBv).unwrap();
         solver.declare_const(&ctx, a).unwrap();
         let res = solver.check_sat_assuming(&ctx, [e]);
         assert_eq!(res.unwrap(), CheckSatResponse::Sat);
@@ -585,6 +581,7 @@ mod tests {
         let eq4 = ctx.build(|c| c.equal(a, c.bit_vec_val(4, 3)));
 
         let mut solver = backend.start(None).unwrap();
+        solver.set_logic(Logic::QfBv).unwrap();
         solver.declare_const(&ctx, a).unwrap();
 
         let res = solver.check_sat_assuming(&ctx, [eq3, eq4]).unwrap();
@@ -610,6 +607,7 @@ mod tests {
         let ge5 = ctx.build(|c| c.greater_or_equal(a, c.bit_vec_val(5, 3)));
 
         let mut solver = backend.start(None).unwrap();
+        solver.set_logic(Logic::QfBv).unwrap();
         solver.declare_const(&ctx, a).unwrap();
         let res = solver
             .check_sat_assuming(&ctx, [smt_false, ge3, ge5])
@@ -637,6 +635,7 @@ mod tests {
         let b_is_1 = ctx.build(|c| c.equal(b, c.bit_vec_val(1, 3))); // unrelated, satisfiable
 
         let mut solver = backend.start(None).unwrap();
+        solver.set_logic(Logic::QfBv).unwrap();
         solver.declare_const(&ctx, a).unwrap();
         solver.declare_const(&ctx, b).unwrap();
 
@@ -664,6 +663,7 @@ mod tests {
         let ge1 = ctx.build(|c| c.greater_or_equal(x, c.bit_vec_val(1, 3)));
 
         let mut solver = backend.start(None).unwrap();
+        solver.set_logic(Logic::QfBv).unwrap();
         solver.declare_const(&ctx, x).unwrap();
 
         let mut act_lits = Vec::with_capacity(3);
@@ -700,6 +700,7 @@ mod tests {
         let b_is_1 = ctx.build(|c| c.equal(b, c.bit_vec_val(1, 3)));
 
         let mut solver = backend.start(None).unwrap();
+        solver.set_logic(Logic::QfBv).unwrap();
         solver.declare_const(&ctx, a).unwrap();
         solver.declare_const(&ctx, b).unwrap();
 
@@ -730,6 +731,7 @@ mod tests {
         let ge1 = ctx.build(|c| c.greater_or_equal(x, c.bit_vec_val(1, 3)));
 
         let mut solver = backend.start(None).unwrap();
+        solver.set_logic(Logic::QfBv).unwrap();
 
         solver.declare_const(&ctx, x).unwrap();
         let res = solver.check_sat_assuming(&ctx, [eq2, ge5, ge1]).unwrap();
@@ -801,7 +803,6 @@ mod tests {
         let eq2 = ctx.build(|c| c.equal(x, c.bit_vec_val(2, 3)));
 
         let mut solver = solver_from_env().start(None).unwrap();
-        // some solvers (e.g. yices2) require a logic before bit-vector sorts are known
         solver.set_logic(Logic::QfBv).unwrap();
         solver.declare_const(&ctx, x).unwrap();
         solver.assert(&ctx, eq2).unwrap();
@@ -828,6 +829,7 @@ mod tests {
         let eq2 = ctx.build(|c| c.equal(x, c.bit_vec_val(2, 3)));
 
         let mut solver = backend.start(None).unwrap();
+        solver.set_logic(Logic::QfBv).unwrap();
         solver.declare_const(&ctx, x).unwrap();
 
         let res = solver.check_sat_assuming(&ctx, [eq2]).unwrap();
@@ -850,8 +852,6 @@ mod tests {
         let mut ctx = Context::default();
         let a = ctx.bv_symbol("a", 3);
         let mut solver = solver_from_env().start(None).unwrap();
-        // some solvers (e.g. yices2) require a logic before bit-vector sorts are known
-        solver.set_logic(Logic::QfBv).unwrap();
         let three = ctx.bit_vec_val(3, 3);
         let four = ctx.bit_vec_val(3, 3);
         solver.define_const(&ctx, a, three).unwrap();

--- a/patronus/tests/pdr.rs
+++ b/patronus/tests/pdr.rs
@@ -153,10 +153,6 @@ fn validate_witness(ctx: &Context, sys: &TransitionSystem, wit: &Witness) {
     }
 }
 
-// Shared, parameterized test bodies. Each takes the `solver` to run against.
-// These are plain functions (not `#[test]`s) so the `#[test]` wrappers below
-// stay one-liners while the logic lives in exactly one place.
-
 fn case_trivial_fail(solver: &SmtLibSolver) {
     let (ctx, sys, res) = run_pdr_str(solver, TRIVIAL_FAIL, None);
 
@@ -211,13 +207,6 @@ fn case_aman_goel_4bit(solver: &SmtLibSolver) {
     let (_, _, res) = run_pdr_file(solver, "../inputs/unittest/aman_goel_4bit.btor", None);
     assert!(matches!(res, ModelCheckResult::Success));
 }
-
-// Thin `#[test]` wrappers. These are real source (not macro- or proc-macro-
-// generated), so IDEs like RustRover show clickable run/debug gutter icons for
-// each one. They all run against whichever solver `solver_from_env()` selects
-// (via the `PATRONUS_TEST_SOLVER` environment variable, defaulting to Bitwuzla),
-// so CI can exercise the whole suite against every configured solver by setting
-// a single environment variable per matrix entry.
 
 #[cfg(test)]
 mod pdr {

--- a/patronus/tests/pdr.rs
+++ b/patronus/tests/pdr.rs
@@ -3,7 +3,7 @@ use patronus::btor2;
 use patronus::expr::Context;
 use patronus::mc::{InitValue, ModelCheckResult, Witness, pdr};
 use patronus::sim::{InitKind, Interpreter, Simulator};
-use patronus::smt::{BITWUZLA, SmtLibSolver, Solver, YICES2};
+use patronus::smt::{SmtLibSolver, Solver, solver_from_env};
 use patronus::system::TransitionSystem;
 use std::path::Path;
 
@@ -153,13 +153,11 @@ fn validate_witness(ctx: &Context, sys: &TransitionSystem, wit: &Witness) {
     }
 }
 
-// Shared, parameterized test bodies. Each takes the `solver` to run against and
-// a `tag` used to prefix the output `.smt` filename, so concurrent runs against
-// different solvers don't clobber each other's replay files. These are plain
-// functions (not `#[test]`s) so the per-solver `#[test]` wrappers below stay
-// one-liners while the logic lives in exactly one place.
+// Shared, parameterized test bodies. Each takes the `solver` to run against.
+// These are plain functions (not `#[test]`s) so the `#[test]` wrappers below
+// stay one-liners while the logic lives in exactly one place.
 
-fn case_trivial_fail(solver: &SmtLibSolver, tag: &str) {
+fn case_trivial_fail(solver: &SmtLibSolver) {
     let (ctx, sys, res) = run_pdr_str(solver, TRIVIAL_FAIL, None);
 
     if let ModelCheckResult::Fail(wit) = res {
@@ -169,7 +167,7 @@ fn case_trivial_fail(solver: &SmtLibSolver, tag: &str) {
     }
 }
 
-fn case_trivial_input_fail(solver: &SmtLibSolver, tag: &str) {
+fn case_trivial_input_fail(solver: &SmtLibSolver) {
     let (ctx, sys, res) = run_pdr_str(solver, TRIGGER_BAD, None);
 
     if let ModelCheckResult::Fail(wit) = res {
@@ -179,7 +177,7 @@ fn case_trivial_input_fail(solver: &SmtLibSolver, tag: &str) {
     }
 }
 
-fn case_overflow_fail(solver: &SmtLibSolver, tag: &str) {
+fn case_overflow_fail(solver: &SmtLibSolver) {
     let (ctx, sys, res) = run_pdr_file(solver, "../inputs/verilog_tests/Overflow.btor", None);
 
     if let ModelCheckResult::Fail(wit) = res {
@@ -189,7 +187,7 @@ fn case_overflow_fail(solver: &SmtLibSolver, tag: &str) {
     }
 }
 
-fn case_simple_fail(solver: &SmtLibSolver, tag: &str) {
+fn case_simple_fail(solver: &SmtLibSolver) {
     let (ctx, sys, res) = run_pdr_str(solver, COUNT_2, None);
 
     if let ModelCheckResult::Fail(wit) = res {
@@ -199,104 +197,65 @@ fn case_simple_fail(solver: &SmtLibSolver, tag: &str) {
     }
 }
 
-fn case_delay(solver: &SmtLibSolver, tag: &str) {
+fn case_delay(solver: &SmtLibSolver) {
     let (_, _, res) = run_pdr_file(solver, "../inputs/verilog_tests/Delay.btor", None);
     assert!(matches!(res, ModelCheckResult::Success));
 }
 
-fn case_swap(solver: &SmtLibSolver, tag: &str) {
+fn case_swap(solver: &SmtLibSolver) {
     let (_, _, res) = run_pdr_file(solver, "../inputs/verilog_tests/Swap.btor", None);
     assert!(matches!(res, ModelCheckResult::Success));
 }
 
-fn case_aman_goel_4bit(solver: &SmtLibSolver, _tag: &str) {
+fn case_aman_goel_4bit(solver: &SmtLibSolver) {
     let (_, _, res) = run_pdr_file(solver, "../inputs/unittest/aman_goel_4bit.btor", None);
     assert!(matches!(res, ModelCheckResult::Success));
 }
 
-// Thin per-solver `#[test]` wrappers. These are real source (not macro- or
-// proc-macro-generated), so IDEs like RustRover show clickable run/debug gutter
-// icons for each one. To run the suite against another backend, copy a module
-// and swap the solver constant + tag, e.g. `mod z3 { ... case_*(&Z3, "z3") }`.
+// Thin `#[test]` wrappers. These are real source (not macro- or proc-macro-
+// generated), so IDEs like RustRover show clickable run/debug gutter icons for
+// each one. They all run against whichever solver `solver_from_env()` selects
+// (via the `PATRONUS_TEST_SOLVER` environment variable, defaulting to Bitwuzla),
+// so CI can exercise the whole suite against every configured solver by setting
+// a single environment variable per matrix entry.
 
 #[cfg(test)]
-mod bitwuzla {
+mod pdr {
     use super::*;
 
     #[test]
     fn test_trivial_fail() {
-        case_trivial_fail(&BITWUZLA, "bitwuzla");
+        case_trivial_fail(&solver_from_env());
     }
 
     #[test]
     fn test_trivial_input_fail() {
-        case_trivial_input_fail(&BITWUZLA, "bitwuzla");
+        case_trivial_input_fail(&solver_from_env());
     }
 
     #[test]
     fn test_overflow_fail() {
-        case_overflow_fail(&BITWUZLA, "bitwuzla");
+        case_overflow_fail(&solver_from_env());
     }
 
     #[test]
     fn test_simple_fail() {
-        case_simple_fail(&BITWUZLA, "bitwuzla");
+        case_simple_fail(&solver_from_env());
     }
 
     #[test]
     fn test_delay() {
-        case_delay(&BITWUZLA, "bitwuzla");
+        case_delay(&solver_from_env());
     }
 
     #[test]
     fn test_swap() {
-        case_swap(&BITWUZLA, "bitwuzla");
+        case_swap(&solver_from_env());
     }
 
     #[ignore = "Cubes are not subsumed in PDR, leading to solver explosion"]
     #[test]
     fn test_aman_goel_4bit() {
-        case_aman_goel_4bit(&BITWUZLA, "bitwuzla");
-    }
-}
-
-#[cfg(test)]
-mod yices2 {
-    use super::*;
-
-    #[test]
-    fn test_trivial_fail() {
-        case_trivial_fail(&YICES2, "yices2");
-    }
-
-    #[test]
-    fn test_trivial_input_fail() {
-        case_trivial_input_fail(&YICES2, "yices2");
-    }
-
-    #[test]
-    fn test_overflow_fail() {
-        case_overflow_fail(&YICES2, "yices2");
-    }
-
-    #[test]
-    fn test_simple_fail() {
-        case_simple_fail(&YICES2, "yices2");
-    }
-
-    #[test]
-    fn test_delay() {
-        case_delay(&YICES2, "yices2");
-    }
-
-    #[test]
-    fn test_swap() {
-        case_swap(&YICES2, "yices2");
-    }
-
-    #[ignore = "Cubes are not subsumed in PDR, leading to solver explosion"]
-    #[test]
-    fn test_aman_goel_4bit() {
-        case_aman_goel_4bit(&YICES2, "yices2");
+        case_aman_goel_4bit(&solver_from_env());
     }
 }


### PR DESCRIPTION
# Changes
- Configure CI/CD matrix for unit tests to set environment variable `PATRONUS_TEST_SOLVER` to configure correct solver
- Added `solver_from_env` function to `solver.rs` to return correct solver instance based on `PATRONUS_TEST_SOLVER`, or return a Bitwuzla instance by default
- Refactored tests to call `solver_from_env` instead of using default Bitwuzla instance, including automatically passing tests for solvers that don't support a given feature (e.g. skipping `(get-unsat-assumptions)` tests for `yices` since the feature is marked as unsupported)
- Relaxed `(get-unsat-assumptions)` tests to not enforce minimal core since some solvers (like CVC5), can return non-minimal cores

# Tests
All regression tests pass

# Future Plans
`yices` does actually support `(check-sat-assuming)` and `(get-unsat-assumptions)`, but only with Boolean literals. After the implementation of activation literals, we plan to implement full solver support (like that for Bitwuzla, Z3, etc.) for `yices`

**Notice**: _an LLM was used to refactor the tests and generate the CI/CD; all output was reviewed for correctness_