### PR TITLE
PDR activation literals

### DIFF
--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -244,7 +244,7 @@ fn query(
 /// **Representation Invariant**: `frames.len() > 0`
 struct BasePdr {
     /// Initial frame
-    init_frame: Cube,
+    init_frame: ExprRef,
 
     /// Frame trace containing frames with blocked cubes
     frames: Vec<Vec<Cube>>,
@@ -256,7 +256,12 @@ impl BasePdr {
     /// # Precondition
     /// State variables in transition system need to be stepped
     /// at two adjacent steps
-    fn init(ctx: &mut Context, sys: &TransitionSystem) -> Self {
+    fn init(
+        ctx: &mut Context,
+        smt_ctx: &mut impl SolverContext,
+        enc: &impl TransitionSystemEncoding,
+        sys: &TransitionSystem,
+    ) -> Result<Self> {
         let mut init_cube = Cube::tru();
 
         // Get all initial states from the system and create equalities between symbol
@@ -268,42 +273,46 @@ impl BasePdr {
             }
         }
 
-        Self {
-            init_frame: init_cube,
+        // Initial frame activation literal
+        let init_act = ctx.bv_symbol("act_0", 1);
+
+        // Create act_0 => init_cube, where init_cube is stepped to the before step
+        let init_expr = init_cube.to_expr(ctx);
+        let init_expr = expr_at_step(ctx, enc, init_expr, FROM_STEP);
+        let imp = ctx.implies(init_act, init_expr);
+
+        // Permanently assert implication in solver
+        smt_ctx.declare_const(ctx, init_act)?;
+        smt_ctx.assert(ctx, imp)?;
+
+        Ok(Self {
+            init_frame: init_act,
             frames: vec![vec![]], // Keep index consistency by adding dummy frame in place of init
-        }
-    }
-
-    /// # Returns
-    /// Cube expression representing initial states covered by initial frame
-    fn init_frame_assumptions(&self, ctx: &mut Context) -> ExprRef {
-        self.init_frame.clone().to_expr(ctx)
-    }
-
-    /// # Preconditions
-    /// `frame` > 0 /\ `frame` < `self.frames.len()`
-    ///
-    /// # Returns
-    /// Clause representing non-init frame
-    fn non_init_frame_assumptions(&self, ctx: &mut Context, frame: FrameId) -> ExprRef {
-        assert!(frame > 0 && frame < self.frames.len());
-
-        // Else, just get conjunction of negated cubes (clauses)
-        self.frames[frame].iter().fold(ctx.get_true(), |acc, cube| {
-            let clause = cube.negate(ctx);
-            ctx.and(acc, clause)
         })
     }
 
     /// # Returns
     /// SMT expression representing over-approximation of states reachable in `frame` steps
-    /// (i.e. state space of `frame`-th frame)
-    fn frame_assumptions(&self, ctx: &mut Context, frame: FrameId) -> ExprRef {
+    /// (i.e. state space of `frame`-th frame), stepped at pre-transition step
+    fn frame_assumptions(
+        &self,
+        ctx: &mut Context,
+        enc: &impl TransitionSystemEncoding,
+        frame: FrameId,
+    ) -> ExprRef {
         if frame == 0 {
-            // Special case: init frame
-            self.init_frame_assumptions(ctx)
+            // Special case: init frame is just activation literal for initial states
+            self.init_frame
         } else {
-            self.non_init_frame_assumptions(ctx, frame)
+            assert!(frame < self.frames.len());
+
+            // Else, just get conjunction of negated cubes (clauses)
+            let expr = self.frames[frame].iter().fold(ctx.get_true(), |acc, cube| {
+                let clause = cube.negate(ctx);
+                ctx.and(acc, clause)
+            });
+
+            expr_at_step(ctx, enc, expr, FROM_STEP)
         }
     }
 
@@ -322,8 +331,8 @@ impl BasePdr {
         let mut assumptions = Vec::new();
 
         // Get frame assumption
-        let frame_assumption = self.frame_assumptions(ctx, cube.frame - 1);
-        assumptions.push(expr_at_step(ctx, enc, frame_assumption, FROM_STEP));
+        let frame_assumption = self.frame_assumptions(ctx, enc, cube.frame - 1);
+        assumptions.push(frame_assumption);
 
         // Next step cube
         let cube_expr = cube.cube.to_expr(ctx);
@@ -391,11 +400,10 @@ impl BasePdr {
             .fold(ctx.get_false(), |acc, &b| ctx.or(acc, b));
 
         // Get frame assumptions for frontier frame
-        let front_assumption = self.frame_assumptions(ctx, front);
-        let front_cur = expr_at_step(ctx, enc, front_assumption, FROM_STEP);
+        let front_assumption = self.frame_assumptions(ctx, enc, front);
 
         // Run query SAT?[R_N /\ \neg P]
-        match query(ctx, smt_ctx, sys, enc, vec![front_cur, bad_expr])? {
+        match query(ctx, smt_ctx, sys, enc, vec![front_assumption, bad_expr])? {
             (CheckSatResponse::Sat, Some(cube)) => {
                 // Safety property violation found: return witness cube
                 Ok(Some(cube))
@@ -542,7 +550,7 @@ pub fn pdr(
     enc.unroll(ctx, smt_ctx)?;
 
     // Initialize PDR
-    let mut state = BasePdr::init(ctx, sys);
+    let mut state = BasePdr::init(ctx, smt_ctx, &enc, sys)?;
 
     // PDR loop
     while state.frontier() <= MAX_FRAMES {

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -239,6 +239,15 @@ fn query(
 // Core PDR
 // -------------------------------------------------------------------------------------------------
 
+/// Frame in PDR
+struct Frame {
+    /// Frame activation literal
+    act: ExprRef,
+
+    /// Blocked cubes in frame
+    cubes: Vec<Cube>,
+}
+
 /// Frame trace maintained by vanilla PDR
 ///
 /// **Representation Invariant**: `frames.len() > 0`
@@ -247,7 +256,10 @@ struct BasePdr {
     init_frame: ExprRef,
 
     /// Frame trace containing frames with blocked cubes
-    frames: Vec<Vec<Cube>>,
+    frames: Vec<Frame>,
+
+    /// Next activation literal identifier
+    next_act_id: u64,
 }
 
 impl BasePdr {
@@ -274,7 +286,7 @@ impl BasePdr {
         }
 
         // Initial frame activation literal
-        let init_act = ctx.bv_symbol("act_0", 1);
+        let init_act = ctx.bv_symbol("__pdr_init_act", 1);
 
         // Create act_0 => init_cube, where init_cube is stepped to the before step
         let init_expr = init_cube.to_expr(ctx);
@@ -287,39 +299,59 @@ impl BasePdr {
 
         Ok(Self {
             init_frame: init_act,
-            frames: vec![vec![]], // Keep index consistency by adding dummy frame in place of init
+            frames: vec![Frame {
+                act: ctx.get_true(),
+                cubes: vec![],
+            }], // Keep index consistency by adding dummy frame in place of init
+            next_act_id: 0,
         })
     }
 
     /// # Returns
-    /// SMT expression representing over-approximation of states reachable in `frame` steps
-    /// (i.e. state space of `frame`-th frame), stepped at pre-transition step
-    fn frame_assumptions(
-        &self,
+    /// New activation literal
+    fn create_act_lit(
+        &mut self,
         ctx: &mut Context,
-        enc: &impl TransitionSystemEncoding,
-        frame: FrameId,
-    ) -> ExprRef {
-        if frame == 0 {
+        smt_ctx: &mut impl SolverContext,
+    ) -> Result<ExprRef> {
+        let act = ctx.bv_symbol(format!("__pdr_act_{}", self.next_act_id).as_str(), 1);
+        self.next_act_id += 1;
+
+        smt_ctx.declare_const(ctx, act)?;
+
+        Ok(act)
+    }
+
+    /// # Returns
+    /// SMT expression asserting over-approximation of states reachable in `frame` steps
+    /// (i.e. state space of `frame`-th frame), stepped at pre-transition step
+    fn frame_assumptions(&self, ctx: &mut Context, frame_id: FrameId) -> ExprRef {
+        if frame_id == 0 {
             // Special case: init frame is just activation literal for initial states
             self.init_frame
         } else {
-            assert!(frame < self.frames.len());
+            assert!(frame_id < self.frames.len());
 
-            // Else, just get conjunction of negated cubes (clauses)
-            let expr = self.frames[frame].iter().fold(ctx.get_true(), |acc, cube| {
-                let clause = cube.negate(ctx);
-                ctx.and(acc, clause)
-            });
-
-            expr_at_step(ctx, enc, expr, FROM_STEP)
+            // Get conjunction with all other frame activation literals negated
+            self.frames
+                .iter()
+                .enumerate()
+                .skip(1) // Prevent dummy frame from poisoning assumptions
+                .fold(ctx.get_true(), |acc, (idx, frame)| {
+                    if idx == frame_id {
+                        ctx.and(acc, frame.act)
+                    } else {
+                        let neg_act = ctx.not(frame.act);
+                        ctx.and(acc, neg_act)
+                    }
+                })
         }
     }
 
     /// Run relative inductiveness query
     /// (i.e. `SAT?[R_{i - 1} /\ \neg c /\ T c']`)
     fn rel_ind(
-        &self,
+        &mut self,
         ctx: &mut Context,
         smt_ctx: &mut impl SolverContext,
         sys: &TransitionSystem,
@@ -331,13 +363,20 @@ impl BasePdr {
         let mut assumptions = Vec::new();
 
         // Get frame assumption
-        let frame_assumption = self.frame_assumptions(ctx, enc, cube.frame - 1);
+        let frame_assumption = self.frame_assumptions(ctx, cube.frame - 1);
         assumptions.push(frame_assumption);
 
-        // Next step cube
-        let cube_expr = cube.cube.to_expr(ctx);
-        let cube_nxt = expr_at_step(ctx, enc, cube_expr, TO_STEP);
-        assumptions.push(cube_nxt);
+        for &lit in &cube.cube.literals {
+            // Step literal
+            let lit_cur = expr_at_step(ctx, enc, lit, TO_STEP);
+
+            // Create activation literal for cube literal and associate with cube literal
+            let act = self.create_act_lit(ctx, smt_ctx)?;
+            let imp = ctx.implies(act, lit_cur);
+            smt_ctx.assert(ctx, imp)?;
+
+            assumptions.push(act);
+        }
 
         // Current step negation cube
         if query_type == RelIndType::Extended {
@@ -354,14 +393,29 @@ impl BasePdr {
     ///
     /// # Preconditions
     /// Input cube must be blocked at frame `cube.frame`
-    fn add_blocked_cube(&mut self, cube: &TimedCube) {
+    fn add_blocked_cube(
+        &mut self,
+        ctx: &mut Context,
+        smt_ctx: &mut impl SolverContext,
+        enc: &impl TransitionSystemEncoding,
+        cube: &TimedCube,
+    ) -> Result<()> {
         // Get frontier index
         let front = cube.frame;
 
+        // Convert blocked cube to stepped expression
+        let cube_expr = cube.cube.negate(ctx);
+        let cube_cur = expr_at_step(ctx, enc, cube_expr, FROM_STEP);
+
         // Add new cube to all frames
         for idx in 1..=front {
-            self.frames[idx].push(cube.cube.clone());
+            let imp = ctx.implies(self.frames[idx].act, cube_cur);
+            smt_ctx.assert(ctx, imp)?;
+
+            self.frames[idx].cubes.push(cube.cube.clone());
         }
+
+        Ok(())
     }
 
     /// Frame identifier for frontier frame
@@ -400,7 +454,7 @@ impl BasePdr {
             .fold(ctx.get_false(), |acc, &b| ctx.or(acc, b));
 
         // Get frame assumptions for frontier frame
-        let front_assumption = self.frame_assumptions(ctx, enc, front);
+        let front_assumption = self.frame_assumptions(ctx, front);
 
         // Run query SAT?[R_N /\ \neg P]
         match query(ctx, smt_ctx, sys, enc, vec![front_assumption, bad_expr])? {
@@ -421,8 +475,14 @@ impl BasePdr {
     }
 
     /// Adds empty frame to frame trace
-    fn add_frame(&mut self) {
-        self.frames.push(Vec::new());
+    fn add_frame(&mut self, ctx: &mut Context, smt_ctx: &mut impl SolverContext) -> Result<()> {
+        // Create new activation literal for frame
+        let act = self.create_act_lit(ctx, smt_ctx)?;
+
+        // Add new frame
+        self.frames.push(Frame { act, cubes: vec![] });
+
+        Ok(())
     }
 
     /// Block cube in frame trace at certain frame
@@ -472,7 +532,7 @@ impl BasePdr {
                 worklist.push(obj);
             } else {
                 // Refine frame trace with cube
-                self.add_blocked_cube(&obj);
+                self.add_blocked_cube(ctx, smt_ctx, enc, &obj)?;
             }
         }
 
@@ -496,11 +556,11 @@ impl BasePdr {
 
         // Try to propagate blocked cubes in each frame forward
         for idx in 1..front {
-            let mut num_left = self.frames[idx].len();
+            let mut num_left = self.frames[idx].cubes.len();
 
-            for cube_idx in 0..self.frames[idx].len() {
+            for cube_idx in 0..self.frames[idx].cubes.len() {
                 // Get cube
-                let cube = self.frames[idx][cube_idx].clone();
+                let cube = self.frames[idx].cubes[cube_idx].clone();
 
                 // Get timed cube for relative inductiveness query
                 let query_cube = TimedCube {
@@ -514,8 +574,16 @@ impl BasePdr {
                     .0
                     == CheckSatResponse::Unsat
                 {
+                    // Convert candidate cube to stepped expression
+                    let cube_expr = cube.negate(ctx);
+                    let cube_cur = expr_at_step(ctx, enc, cube_expr, FROM_STEP);
+
+                    // Associate cube with next frame in solver
+                    let imp = ctx.implies(self.frames[idx + 1].act, cube_cur);
+                    smt_ctx.assert(ctx, imp)?;
+
                     // Add blocked cube to next frame
-                    self.frames[idx + 1].push(cube.clone());
+                    self.frames[idx + 1].cubes.push(cube.clone());
                     num_left -= 1;
                 }
             }
@@ -583,7 +651,7 @@ pub fn pdr(
             }
         } else {
             // Add new frame
-            state.add_frame();
+            state.add_frame(ctx, smt_ctx)?;
 
             // Check if inductive invariant found
             if state.propagate_blocked_cubes(ctx, smt_ctx, sys, &enc)? {

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -366,17 +366,14 @@ impl BasePdr {
         let frame_assumption = self.frame_assumptions(ctx, cube.frame - 1);
         assumptions.push(frame_assumption);
 
-        for &lit in &cube.cube.literals {
-            // Step literal
-            let lit_cur = expr_at_step(ctx, enc, lit, TO_STEP);
-
-            // Create activation literal for cube literal and associate with cube literal
-            let act = self.create_act_lit(ctx, smt_ctx)?;
-            let imp = ctx.implies(act, lit_cur);
-            smt_ctx.assert(ctx, imp)?;
-
-            assumptions.push(act);
-        }
+        // Add next state cube as literal assumptions (helpful for UNSAT core generalization)
+        assumptions.extend(
+            cube.cube
+                .literals
+                .iter()
+                .map(|&e| expr_at_step(ctx, enc, e, TO_STEP))
+                .collect::<Vec<_>>(),
+        );
 
         // Current step negation cube
         if query_type == RelIndType::Extended {

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -366,14 +366,10 @@ impl BasePdr {
         let frame_assumption = self.frame_assumptions(ctx, cube.frame - 1);
         assumptions.push(frame_assumption);
 
-        // Add next state cube as literal assumptions (helpful for UNSAT core generalization)
-        assumptions.extend(
-            cube.cube
-                .literals
-                .iter()
-                .map(|&e| expr_at_step(ctx, enc, e, TO_STEP))
-                .collect::<Vec<_>>(),
-        );
+        // Next step cube
+        let cube_expr = cube.cube.to_expr(ctx);
+        let cube_next = expr_at_step(ctx, enc, cube_expr, TO_STEP);
+        assumptions.push(cube_next);
 
         // Current step negation cube
         if query_type == RelIndType::Extended {

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -243,6 +243,9 @@ fn query(
 ///
 /// **Representation Invariant**: `frames.len() > 0`
 struct BasePdr {
+    /// Initial frame
+    init_frame: Cube,
+
     /// Frame trace containing frames with blocked cubes
     frames: Vec<Vec<Cube>>,
 }
@@ -266,25 +269,41 @@ impl BasePdr {
         }
 
         Self {
-            frames: vec![vec![init_cube]],
+            init_frame: init_cube,
+            frames: vec![vec![]], // Keep index consistency by adding dummy frame in place of init
         }
     }
 
     /// # Returns
-    /// * Clause representing non-init frame
-    /// * Cube representing init frame
-    fn frame_assumptions(&self, ctx: &mut Context, frame: FrameId) -> ExprRef {
-        assert!(frame < self.frames.len());
+    /// Cube expression representing initial states covered by initial frame
+    fn init_frame_assumptions(&self, ctx: &mut Context) -> ExprRef {
+        self.init_frame.clone().to_expr(ctx)
+    }
 
+    /// # Preconditions
+    /// `frame` > 0 /\ `frame` < `self.frames.len()`
+    ///
+    /// # Returns
+    /// Clause representing non-init frame
+    fn non_init_frame_assumptions(&self, ctx: &mut Context, frame: FrameId) -> ExprRef {
+        assert!(frame > 0 && frame < self.frames.len());
+
+        // Else, just get conjunction of negated cubes (clauses)
+        self.frames[frame].iter().fold(ctx.get_true(), |acc, cube| {
+            let clause = cube.negate(ctx);
+            ctx.and(acc, clause)
+        })
+    }
+
+    /// # Returns
+    /// SMT expression representing over-approximation of states reachable in `frame` steps
+    /// (i.e. state space of `frame`-th frame)
+    fn frame_assumptions(&self, ctx: &mut Context, frame: FrameId) -> ExprRef {
         if frame == 0 {
-            // Special case: init frame is just conjunction
-            self.frames[0][0].to_expr(ctx)
+            // Special case: init frame
+            self.init_frame_assumptions(ctx)
         } else {
-            // Else, just get conjunction of negated cubes (clauses)
-            self.frames[frame].iter().fold(ctx.get_true(), |acc, cube| {
-                let clause = cube.negate(ctx);
-                ctx.and(acc, clause)
-            })
+            self.non_init_frame_assumptions(ctx, frame)
         }
     }
 

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -115,6 +115,12 @@ enum RelIndType {
 }
 
 /// Frame identifier
+///
+/// Equality is defined by constructor and inner fields (i.e. `FrameId::Init == FrameId::Init`,
+/// `FrameId::Finite(5) == FrameId::Finite(5)`)
+///
+/// Comparison is defined as a partial order where `FrameId::Init` <= `FrameId::Finite` and
+/// `FrameId::Finite` is compared against inner field
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum FrameId {
     /// Initial frame
@@ -141,10 +147,13 @@ impl FrameId {
         match self {
             Self::Init => panic!("Cannot decrement init"),
             Self::Finite(n) => {
-                if n.get() - 1 == 0 {
+                let fin = n.get() - 1;
+
+                if fin == 0 {
+                    // Decremented to init frame
                     Self::Init
                 } else {
-                    Self::Finite(NonZeroUsize::new(n.get() - 1).unwrap())
+                    Self::Finite(NonZeroUsize::new(fin).unwrap())
                 }
             }
         }
@@ -302,7 +311,7 @@ impl Frame {
         let clause_expr = expr_at_step(ctx, enc, clause, FROM_STEP);
         let imp = ctx.implies(self.act, clause_expr);
 
-        // Permanently assert in solver
+        // Permanently assert implication in solver
         smt_ctx.assert(ctx, imp)?;
 
         // Add blocked cube to frame
@@ -326,9 +335,12 @@ struct BasePdr {
     next_act_id: u64,
 }
 
+/// Indexing into frames for [`BasePdr`]
 impl Index<FrameId> for BasePdr {
     type Output = Frame;
 
+    /// # Panics
+    /// When indexing init frame
     fn index(&self, index: FrameId) -> &Self::Output {
         match index {
             FrameId::Init => panic!("Cannot index init frame"), // Init frame doesn't explicitly exist
@@ -337,7 +349,7 @@ impl Index<FrameId> for BasePdr {
     }
 }
 
-/// Indexing into frames for `BasePdr`
+/// Indexing into frames for [`BasePdr`] (mutable reference)
 impl IndexMut<FrameId> for BasePdr {
     fn index_mut(&mut self, index: FrameId) -> &mut Self::Output {
         match index {
@@ -347,7 +359,7 @@ impl IndexMut<FrameId> for BasePdr {
     }
 }
 
-/// Iterator for `BasePdr`
+/// Iterator for [`BasePdr`]
 struct BasePdrIterator<'a> {
     frames: &'a Vec<Frame>,
     cur_idx: usize,
@@ -370,7 +382,7 @@ impl<'a> Iterator for BasePdrIterator<'a> {
     }
 }
 
-/// Iterator method for `BasePdr`
+/// Iterator method for [`BasePdr`]
 impl BasePdr {
     const fn iter(&'_ self) -> BasePdrIterator<'_> {
         BasePdrIterator {
@@ -380,7 +392,7 @@ impl BasePdr {
     }
 }
 
-/// Iterator convenience method for `BasePdr`
+/// Implicit iterator conversion for [`BasePdr`]
 impl<'a> IntoIterator for &'a mut BasePdr {
     type Item = FrameId;
     type IntoIter = BasePdrIterator<'a>;
@@ -460,7 +472,8 @@ impl BasePdr {
                     // Include activation literals of target frame
                     ctx.and(acc, self[id].act)
                 } else {
-                    // Avoid solver bloat by setting "disabling" other activation literals
+                    // Avoid solver bloat/slowdown by "disabling" other activation literals
+                    // NOTE: will be fixed with delta frame trace
                     let neg_act = ctx.not(self[id].act);
                     ctx.and(acc, neg_act)
                 }
@@ -516,7 +529,7 @@ impl BasePdr {
         // Get frontier index
         let front = cube.frame;
 
-        // Get identifiers until front index
+        // Get frame identifiers up to and including front index
         let ids = self
             .iter()
             .take_while(|id| id <= &front)

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -12,6 +12,8 @@ use crate::smt::*;
 use crate::system::TransitionSystem;
 use baa::{BitVecOps, Value};
 use std::collections::BinaryHeap;
+use std::num::NonZeroUsize;
+use std::ops::{Index, IndexMut};
 
 type Step = u64;
 
@@ -20,6 +22,9 @@ const FROM_STEP: Step = 1;
 const TO_STEP: Step = 2;
 
 const MAX_FRAMES: usize = 1000;
+
+/// Activation literal prefix
+const ACT_LIT_PREFIX: &str = "__pdr_act_";
 
 // -------------------------------------------------------------------------------------------------
 // Core PDR data structures
@@ -59,13 +64,11 @@ impl Cube {
     }
 }
 
-type FrameId = usize;
-
 /// Cube and relevant frame identifier
 #[derive(Debug, Clone)]
 struct TimedCube {
     cube: Cube,
-    frame: usize,
+    frame: FrameId,
 }
 
 // Equality comparators for `TimedCube`
@@ -109,6 +112,43 @@ enum RelIndType {
 
     /// Extended query (`SAT?[R_{i - 1} /\ \neg c /\ T /\ c']`)
     Extended,
+}
+
+/// Frame identifier
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum FrameId {
+    /// Initial frame
+    Init,
+
+    /// Finite, non-initial frame
+    Finite(NonZeroUsize),
+}
+
+impl FrameId {
+    /// Increment frame identifier
+    const fn increment(self) -> Self {
+        match self {
+            Self::Init => Self::Finite(NonZeroUsize::new(1).unwrap()),
+            Self::Finite(n) => Self::Finite(NonZeroUsize::new(n.get() + 1).unwrap()),
+        }
+    }
+
+    /// Decrement frame identifier
+    ///
+    /// # Panics
+    /// If [`FrameId::Init`] is decremented
+    fn decrement(self) -> Self {
+        match self {
+            Self::Init => panic!("Cannot decrement init"),
+            Self::Finite(n) => {
+                if n.get() - 1 == 0 {
+                    Self::Init
+                } else {
+                    Self::Finite(NonZeroUsize::new(n.get() - 1).unwrap())
+                }
+            }
+        }
+    }
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -248,6 +288,30 @@ struct Frame {
     cubes: Vec<Cube>,
 }
 
+impl Frame {
+    /// Add blocked cube to this frame
+    fn add_blocked_cube(
+        &mut self,
+        ctx: &mut Context,
+        smt_ctx: &mut impl SolverContext,
+        enc: &impl TransitionSystemEncoding,
+        cube: &Cube,
+    ) -> Result<()> {
+        // Create implication act_i => \neg c, where c is the blocked cube stepped at current step
+        let clause = cube.negate(ctx);
+        let clause_expr = expr_at_step(ctx, enc, clause, FROM_STEP);
+        let imp = ctx.implies(self.act, clause_expr);
+
+        // Permanently assert in solver
+        smt_ctx.assert(ctx, imp)?;
+
+        // Add blocked cube to frame
+        self.cubes.push(cube.clone());
+
+        Ok(())
+    }
+}
+
 /// Frame trace maintained by vanilla PDR
 ///
 /// **Representation Invariant**: `frames.len() > 0`
@@ -260,6 +324,69 @@ struct BasePdr {
 
     /// Next activation literal identifier
     next_act_id: u64,
+}
+
+impl Index<FrameId> for BasePdr {
+    type Output = Frame;
+
+    fn index(&self, index: FrameId) -> &Self::Output {
+        match index {
+            FrameId::Init => panic!("Cannot index init frame"), // Init frame doesn't explicitly exist
+            FrameId::Finite(n) => &self.frames[n.get() - 1],
+        }
+    }
+}
+
+/// Indexing into frames for `BasePdr`
+impl IndexMut<FrameId> for BasePdr {
+    fn index_mut(&mut self, index: FrameId) -> &mut Self::Output {
+        match index {
+            FrameId::Init => panic!("Cannot index init frame"), // Init frame doesn't explicitly exist
+            FrameId::Finite(n) => &mut self.frames[n.get() - 1],
+        }
+    }
+}
+
+/// Iterator for `BasePdr`
+struct BasePdrIterator<'a> {
+    frames: &'a Vec<Frame>,
+    cur_idx: usize,
+}
+
+/// Iterator yields frame identifiers for all non-init, finite frames
+//
+/// **NOTE**: skips init frame since it doesn't exist explicitly in struct
+impl<'a> Iterator for BasePdrIterator<'a> {
+    /// Pair of frame identifiers and reference to frame
+    type Item = FrameId;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.cur_idx < self.frames.len() {
+            self.cur_idx += 1;
+            Some(FrameId::Finite(NonZeroUsize::new(self.cur_idx).unwrap()))
+        } else {
+            None
+        }
+    }
+}
+
+/// Iterator method for `BasePdr`
+impl BasePdr {
+    const fn iter(&'_ self) -> BasePdrIterator<'_> {
+        BasePdrIterator {
+            frames: &self.frames,
+            cur_idx: 0,
+        }
+    }
+}
+
+/// Iterator convenience method for `BasePdr`
+impl<'a> IntoIterator for &'a mut BasePdr {
+    type Item = FrameId;
+    type IntoIter = BasePdrIterator<'a>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
 }
 
 impl BasePdr {
@@ -286,7 +413,7 @@ impl BasePdr {
         }
 
         // Initial frame activation literal
-        let init_act = ctx.bv_symbol("__pdr_init_act", 1);
+        let init_act = ctx.bv_symbol(format!("{ACT_LIT_PREFIX}_init").as_str(), 1);
 
         // Create act_0 => init_cube, where init_cube is stepped to the before step
         let init_expr = init_cube.to_expr(ctx);
@@ -299,10 +426,7 @@ impl BasePdr {
 
         Ok(Self {
             init_frame: init_act,
-            frames: vec![Frame {
-                act: ctx.get_true(),
-                cubes: vec![],
-            }], // Keep index consistency by adding dummy frame in place of init
+            frames: vec![], // Index consistency taken care by indexing function
             next_act_id: 0,
         })
     }
@@ -326,32 +450,28 @@ impl BasePdr {
     /// SMT expression asserting over-approximation of states reachable in `frame` steps
     /// (i.e. state space of `frame`-th frame), stepped at pre-transition step
     fn frame_assumptions(&self, ctx: &mut Context, frame_id: FrameId) -> ExprRef {
-        if frame_id == 0 {
+        if frame_id == FrameId::Init {
             // Special case: init frame is just activation literal for initial states
             self.init_frame
         } else {
-            assert!(frame_id < self.frames.len());
-
             // Get conjunction with all other frame activation literals negated
-            self.frames
-                .iter()
-                .enumerate()
-                .skip(1) // Prevent dummy frame from poisoning assumptions
-                .fold(ctx.get_true(), |acc, (idx, frame)| {
-                    if idx == frame_id {
-                        ctx.and(acc, frame.act)
-                    } else {
-                        let neg_act = ctx.not(frame.act);
-                        ctx.and(acc, neg_act)
-                    }
-                })
+            self.iter().fold(ctx.get_true(), |acc, id| {
+                if id == frame_id {
+                    // Include activation literals of target frame
+                    ctx.and(acc, self[id].act)
+                } else {
+                    // Avoid solver bloat by setting "disabling" other activation literals
+                    let neg_act = ctx.not(self[id].act);
+                    ctx.and(acc, neg_act)
+                }
+            })
         }
     }
 
     /// Run relative inductiveness query
     /// (i.e. `SAT?[R_{i - 1} /\ \neg c /\ T c']`)
     fn rel_ind(
-        &mut self,
+        &self,
         ctx: &mut Context,
         smt_ctx: &mut impl SolverContext,
         sys: &TransitionSystem,
@@ -363,7 +483,7 @@ impl BasePdr {
         let mut assumptions = Vec::new();
 
         // Get frame assumption
-        let frame_assumption = self.frame_assumptions(ctx, cube.frame - 1);
+        let frame_assumption = self.frame_assumptions(ctx, cube.frame.decrement());
         assumptions.push(frame_assumption);
 
         // Next step cube
@@ -396,16 +516,15 @@ impl BasePdr {
         // Get frontier index
         let front = cube.frame;
 
-        // Convert blocked cube to stepped expression
-        let cube_expr = cube.cube.negate(ctx);
-        let cube_cur = expr_at_step(ctx, enc, cube_expr, FROM_STEP);
+        // Get identifiers until front index
+        let ids = self
+            .iter()
+            .take_while(|id| id <= &front)
+            .collect::<Vec<_>>();
 
         // Add new cube to all frames
-        for idx in 1..=front {
-            let imp = ctx.implies(self.frames[idx].act, cube_cur);
-            smt_ctx.assert(ctx, imp)?;
-
-            self.frames[idx].cubes.push(cube.cube.clone());
+        for id in ids {
+            self[id].add_blocked_cube(ctx, smt_ctx, enc, &cube.cube)?;
         }
 
         Ok(())
@@ -413,7 +532,11 @@ impl BasePdr {
 
     /// Frame identifier for frontier frame
     const fn frontier(&self) -> FrameId {
-        self.frames.len() - 1
+        if self.frames.is_empty() {
+            FrameId::Init
+        } else {
+            FrameId::Finite(NonZeroUsize::new(self.frames.len()).unwrap())
+        }
     }
 
     /// Try to extract safety property violation at frontier frame
@@ -499,7 +622,7 @@ impl BasePdr {
         // Try to solve all proof obligations
         while let Some(obj) = worklist.pop() {
             // If initial frame reached, concrete counterexample trace found: fail
-            if obj.frame == 0 {
+            if obj.frame == FrameId::Init {
                 return Ok(false);
             }
 
@@ -520,7 +643,7 @@ impl BasePdr {
                 // Counterexample found: try to block predecessor and current obligation
                 worklist.push(TimedCube {
                     cube: wit,
-                    frame: obj.frame - 1,
+                    frame: obj.frame.decrement(),
                 });
                 worklist.push(obj);
             } else {
@@ -547,18 +670,21 @@ impl BasePdr {
         // Get frame index
         let front = self.frontier();
 
-        // Try to propagate blocked cubes in each frame forward
-        for idx in 1..front {
-            let mut num_left = self.frames[idx].cubes.len();
+        // Get ids until the front identifier
+        let ids = self.iter().take_while(|id| id < &front).collect::<Vec<_>>();
 
-            for cube_idx in 0..self.frames[idx].cubes.len() {
+        // Try to propagate blocked cubes in each frame forward
+        for id in ids {
+            let mut num_left = self[id].cubes.len();
+
+            for cube_idx in 0..self[id].cubes.len() {
                 // Get cube
-                let cube = self.frames[idx].cubes[cube_idx].clone();
+                let cube = self[id].cubes[cube_idx].clone();
 
                 // Get timed cube for relative inductiveness query
                 let query_cube = TimedCube {
                     cube: cube.clone(),
-                    frame: idx + 1,
+                    frame: id.increment(),
                 };
 
                 // Check that cube is still blocked in next frame
@@ -567,16 +693,8 @@ impl BasePdr {
                     .0
                     == CheckSatResponse::Unsat
                 {
-                    // Convert candidate cube to stepped expression
-                    let cube_expr = cube.negate(ctx);
-                    let cube_cur = expr_at_step(ctx, enc, cube_expr, FROM_STEP);
-
-                    // Associate cube with next frame in solver
-                    let imp = ctx.implies(self.frames[idx + 1].act, cube_cur);
-                    smt_ctx.assert(ctx, imp)?;
-
                     // Add blocked cube to next frame
-                    self.frames[idx + 1].cubes.push(cube.clone());
+                    self[id.increment()].add_blocked_cube(ctx, smt_ctx, enc, &cube)?;
                     num_left -= 1;
                 }
             }
@@ -614,7 +732,7 @@ pub fn pdr(
     let mut state = BasePdr::init(ctx, smt_ctx, &enc, sys)?;
 
     // PDR loop
-    while state.frontier() <= MAX_FRAMES {
+    while state.frontier() <= FrameId::Finite(NonZeroUsize::new(MAX_FRAMES).unwrap()) {
         // Try to get bad cube
         let bad_cube = state.get_bad_cube(ctx, smt_ctx, sys, &enc)?;
 

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -114,8 +114,6 @@ enum RelIndType {
     Extended,
 }
 
-/// Frame identifier
-///
 /// Equality is defined by constructor and inner fields (i.e. `FrameId::Init == FrameId::Init`,
 /// `FrameId::Finite(5) == FrameId::Finite(5)`)
 ///
@@ -131,7 +129,6 @@ enum FrameId {
 }
 
 impl FrameId {
-    /// Increment frame identifier
     const fn increment(self) -> Self {
         match self {
             Self::Init => Self::Finite(NonZeroUsize::new(1).unwrap()),
@@ -139,8 +136,6 @@ impl FrameId {
         }
     }
 
-    /// Decrement frame identifier
-    ///
     /// # Panics
     /// If [`FrameId::Init`] is decremented
     fn decrement(self) -> Self {
@@ -288,7 +283,6 @@ fn query(
 // Core PDR
 // -------------------------------------------------------------------------------------------------
 
-/// Frame in PDR
 struct Frame {
     /// Frame activation literal
     act: ExprRef,
@@ -298,7 +292,6 @@ struct Frame {
 }
 
 impl Frame {
-    /// Add blocked cube to this frame
     fn add_blocked_cube(
         &mut self,
         ctx: &mut Context,
@@ -331,11 +324,10 @@ struct BasePdr {
     /// Frame trace containing frames with blocked cubes
     frames: Vec<Frame>,
 
-    /// Next activation literal identifier
+    /// Incrementing counter for creating unique frame activation literal IDs
     next_act_id: u64,
 }
 
-/// Indexing into frames for [`BasePdr`]
 impl Index<FrameId> for BasePdr {
     type Output = Frame;
 
@@ -349,7 +341,6 @@ impl Index<FrameId> for BasePdr {
     }
 }
 
-/// Indexing into frames for [`BasePdr`] (mutable reference)
 impl IndexMut<FrameId> for BasePdr {
     fn index_mut(&mut self, index: FrameId) -> &mut Self::Output {
         match index {
@@ -359,45 +350,10 @@ impl IndexMut<FrameId> for BasePdr {
     }
 }
 
-/// Iterator for [`BasePdr`]
-struct BasePdrIterator<'a> {
-    frames: &'a Vec<Frame>,
-    cur_idx: usize,
-}
-
-/// Iterator yields frame identifiers for all non-init, finite frames
-//
-/// **NOTE**: skips init frame since it doesn't exist explicitly in struct
-impl<'a> Iterator for BasePdrIterator<'a> {
-    /// Pair of frame identifiers and reference to frame
-    type Item = FrameId;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.cur_idx < self.frames.len() {
-            self.cur_idx += 1;
-            Some(FrameId::Finite(NonZeroUsize::new(self.cur_idx).unwrap()))
-        } else {
-            None
-        }
-    }
-}
-
 /// Iterator method for [`BasePdr`]
 impl BasePdr {
-    const fn iter(&'_ self) -> BasePdrIterator<'_> {
-        BasePdrIterator {
-            frames: &self.frames,
-            cur_idx: 0,
-        }
-    }
-}
-
-/// Implicit iterator conversion for [`BasePdr`]
-impl<'a> IntoIterator for &'a mut BasePdr {
-    type Item = FrameId;
-    type IntoIter = BasePdrIterator<'a>;
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
+    fn iter(&'_ self) -> impl Iterator<Item = FrameId> + '_ {
+        (1..=self.frames.len()).map(|ii| FrameId::Finite(NonZeroUsize::new(ii).unwrap()))
     }
 }
 
@@ -473,7 +429,13 @@ impl BasePdr {
                     ctx.and(acc, self[id].act)
                 } else {
                     // Avoid solver bloat/slowdown by "disabling" other activation literals
-                    // NOTE: will be fixed with delta frame trace
+                    //
+                    // Sound since the actual state space represented by the `frame_id`-th
+                    // frame is directly "activated" by `self[frame_id].act`. Allowing the solver
+                    // to explore activation for the other frames would be redundant (for the
+                    // upper frames) or unsound (for the lower frames)
+                    //
+                    // Note: must only "disable" lower frames once delta frames are implemented
                     let neg_act = ctx.not(self[id].act);
                     ctx.and(acc, neg_act)
                 }
@@ -785,4 +747,40 @@ pub fn pdr(
     }
 
     Ok(ModelCheckResult::Unknown)
+}
+
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_frame_id_cmp() {
+        assert!(FrameId::Init < FrameId::Finite(NonZeroUsize::new(1).unwrap()));
+        assert!(FrameId::Init < FrameId::Finite(NonZeroUsize::new(5).unwrap()));
+        assert!(
+            FrameId::Finite(NonZeroUsize::new(3).unwrap())
+                < FrameId::Finite(NonZeroUsize::new(5).unwrap())
+        );
+        assert!(FrameId::Init >= FrameId::Init);
+        assert!(
+            FrameId::Finite(NonZeroUsize::new(5).unwrap())
+                >= FrameId::Finite(NonZeroUsize::new(5).unwrap())
+        );
+    }
+
+    #[test]
+    fn test_frame_id_eq() {
+        assert_ne!(
+            FrameId::Init,
+            FrameId::Finite(NonZeroUsize::new(1).unwrap())
+        );
+        assert_ne!(
+            FrameId::Finite(NonZeroUsize::new(2).unwrap()),
+            FrameId::Finite(NonZeroUsize::new(1).unwrap())
+        );
+        assert_eq!(FrameId::Init, FrameId::Init);
+        assert_eq!(
+            FrameId::Finite(NonZeroUsize::new(1).unwrap()),
+            FrameId::Finite(NonZeroUsize::new(1).unwrap())
+        );
+    }
 }


### PR DESCRIPTION
# Changes
- Added frame-level activation literals (for every blocked cube $\neg c$, there exists the implication $act_i \Rightarrow \neg c$ in the solver, where $act_i$ is the activation literal for the frame, $i > 0$)
- Added activation literal generation function `create_act_lit` to automatically intern and define activation literals in the `Context` and `SolverContext`, respectively

# Tests
All regression tests pass

# Future Work
- Cache `FROM_STEP` and `TO_STEP` versions of `Cube` directly in the `Cube` struct itself