### PR TITLE
Added PDR driver code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,8 +58,8 @@ jobs:
       env:
         PATRONUS_TEST_SOLVER: ${{ matrix.solver }}
 
-  bmc:
-    name: Test BMC Tool
+  mc:
+    name: Test MC Tool with BMC
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     strategy:
@@ -107,33 +107,33 @@ jobs:
       - name: Update Rust to ${{ matrix.toolchain }}
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - name: Build
-        run: cargo build --verbose --release -p bmc
-      - name: bmc Quiz1
+        run: cargo build --verbose --release -p mc
+      - name: mc Quiz1
         run: |
-          cargo run --release -p bmc -- --solver=${{ matrix.solver }} inputs/chiseltest/Quiz1.btor > Quiz1.wit
+          cargo run --release -p mc -- --solver=${{ matrix.solver }} inputs/chiseltest/Quiz1.btor > Quiz1.wit
           btorsim inputs/chiseltest/Quiz1.btor Quiz1.wit
-      - name: bmc Quiz1 (with additional assumption)
+      - name: mc Quiz1 (with additional assumption)
         run: |
-          cargo run --release -p bmc -- --solver=${{ matrix.solver }} inputs/chiseltest/Quiz1.unsat.btor
-      - name: bmc const array example
+          cargo run --release -p mc -- --solver=${{ matrix.solver }} inputs/chiseltest/Quiz1.unsat.btor
+      - name: mc const array example
         if: ${{ matrix.solver != 'yices2' }} # yices2 returns memory values that cannot be parsed
         run: |
-          cargo run --release -p bmc -- --solver=${{ matrix.solver }} inputs/chiseltest/const_array_example.btor > const_array_example.wit
+          cargo run --release -p mc -- --solver=${{ matrix.solver }} inputs/chiseltest/const_array_example.btor > const_array_example.wit
           btorsim inputs/chiseltest/const_array_example.btor const_array_example.wit
-      - name: bmc Quiz2
+      - name: mc Quiz2
         run: |
-          cargo run --release -p bmc -- --solver=${{ matrix.solver }} inputs/chiseltest/Quiz2.sat.btor > Quiz2.sat.wit
+          cargo run --release -p mc -- --solver=${{ matrix.solver }} inputs/chiseltest/Quiz2.sat.btor > Quiz2.sat.wit
           btorsim inputs/chiseltest/Quiz2.sat.btor Quiz2.sat.wit
-      - name: bmc Quiz2 (with counter reset value)
+      - name: mc Quiz2 (with counter reset value)
         run: |
-          cargo run --release -p bmc -- --solver=${{ matrix.solver }} inputs/chiseltest/Quiz2.unsat.btor
-      - name: bmc Quiz4
+          cargo run --release -p mc -- --solver=${{ matrix.solver }} inputs/chiseltest/Quiz2.unsat.btor
+      - name: mc Quiz4
         run: |
-          cargo run --release -p bmc -- --solver=${{ matrix.solver }} inputs/chiseltest/Quiz4.sat.btor > Quiz4.sat.wit
+          cargo run --release -p mc -- --solver=${{ matrix.solver }} inputs/chiseltest/Quiz4.sat.btor > Quiz4.sat.wit
           btorsim inputs/chiseltest/Quiz4.sat.btor Quiz4.sat.wit
-      - name: bmc Quiz4 (with counter reset value)
+      - name: mc Quiz4 (with counter reset value)
         run: |
-          cargo run --release -p bmc -- --solver=${{ matrix.solver }} inputs/chiseltest/Quiz4.unsat.btor
+          cargo run --release -p mc -- --solver=${{ matrix.solver }} inputs/chiseltest/Quiz4.unsat.btor
 
   sim:
     name: Test Simulator Tool

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["patronus", "patronus-egraphs", "patronus-dse", "tools/bmc", "tools/egraphs-cond-synth", "tools/sim", "tools/simplify", "tools/view", "python"]
+members = ["patronus", "patronus-egraphs", "patronus-dse", "tools/mc", "tools/egraphs-cond-synth", "tools/sim", "tools/simplify", "tools/view", "python"]
 
 [workspace.package]
 edition = "2024"

--- a/tools/mc/Cargo.toml
+++ b/tools/mc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "bmc"
+name = "mc"
 version = "0.1.0"
-description = "A simple bounded model checking tool based on the patronus library."
+description = "A simple model checking tool based on the patronus library."
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/tools/mc/src/main.rs
+++ b/tools/mc/src/main.rs
@@ -117,11 +117,7 @@ fn main() {
             check_bad_states_individually,
             k_max,
         ),
-        ModelCheckEngine::Pdr => pdr(
-            &mut ctx,
-            &mut smt_ctx,
-            &sys,
-        ),
+        ModelCheckEngine::Pdr => pdr(&mut ctx, &mut smt_ctx, &sys),
     }
     .unwrap();
     match res {

--- a/tools/mc/src/main.rs
+++ b/tools/mc/src/main.rs
@@ -3,19 +3,20 @@
 // released under BSD 3-Clause License
 // author: Kevin Laeufer <laeufer@cornell.edu>
 
-use clap::{Parser, ValueEnum};
+use clap::error::ErrorKind;
+use clap::{CommandFactory, Parser, ValueEnum};
 use patronus::expr::*;
-use patronus::mc::bmc;
+use patronus::mc::{bmc, pdr};
 use patronus::smt::*;
 use patronus::system::transform::simplify_expressions;
 use patronus::*;
 use std::fs::File;
 
 #[derive(Parser, Debug)]
-#[command(name = "bmc")]
+#[command(name = "mc")]
 #[command(author = "Kevin Laeufer <laeufer@berkeley.edu>")]
 #[command(version)]
-#[command(about = "Performs bounded model checking on a btor2 file.", long_about = None)]
+#[command(about = "Performs model checking on a btor2 file.", long_about = None)]
 struct Args {
     #[arg(
         long,
@@ -24,8 +25,10 @@ struct Args {
         help = "the SMT solver to use"
     )]
     solver: SolverChoice,
-    #[arg(short, long, default_value = "25")]
-    kmax: u64,
+    #[arg(short, long, default_value = "bmc", help = "model checking engine")]
+    engine: ModelCheckEngine,
+    #[arg(short, long, help = "max BMC depth (bmc engine only) [default: 25]")]
+    kmax: Option<u64>,
     #[arg(short, long)]
     verbose: bool,
     #[arg(short, long)]
@@ -44,8 +47,25 @@ pub enum SolverChoice {
     CVC5,
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum ModelCheckEngine {
+    Bmc,
+    Pdr,
+}
+
 fn main() {
     let args = Args::parse();
+
+    if args.kmax.is_some() && args.engine != ModelCheckEngine::Bmc {
+        Args::command()
+            .error(
+                ErrorKind::ArgumentConflict,
+                "--kmax can only be used with the bmc engine (--engine bmc)",
+            )
+            .exit();
+    }
+    let kmax = args.kmax.unwrap_or(25);
+
     let (mut ctx, mut sys) = btor2::parse_file(&args.filename).expect("Failed to load btor2 file!");
     if !args.skip_simplify {
         if args.verbose {
@@ -69,7 +89,7 @@ fn main() {
         }
         0
     } else {
-        args.kmax
+        kmax
     };
     let check_constraints = true;
     let check_bad_states_individually = false;
@@ -88,14 +108,21 @@ fn main() {
         None
     };
     let mut smt_ctx = solver.start(dump_file).expect("failed to start solver");
-    let res = bmc(
-        &mut ctx,
-        &mut smt_ctx,
-        &sys,
-        check_constraints,
-        check_bad_states_individually,
-        k_max,
-    )
+    let res = match args.engine {
+        ModelCheckEngine::Bmc => bmc(
+            &mut ctx,
+            &mut smt_ctx,
+            &sys,
+            check_constraints,
+            check_bad_states_individually,
+            k_max,
+        ),
+        ModelCheckEngine::Pdr => pdr(
+            &mut ctx,
+            &mut smt_ctx,
+            &sys,
+        ),
+    }
     .unwrap();
     match res {
         mc::ModelCheckResult::Success => {


### PR DESCRIPTION
# Changes
- Renamed `tools/bmc` package to `tools/mc`
- Refactored CI/CD to use new `mc` package name
- Added command-argument `--engine` that can take either `bmc` or `pdr` to use specific model checking engine (default to `bmc`)
- Added error handling for erroneous `--kmax` option declaration with `--engine pdr`

# Tests
Manually tested model checking tool with `btor` files. Tool correctly runs specified model checking algorithm, returns correct model checking result, and displays counterexample trace on `SAT` cases. 

**Notice**: _an LLM was used to refactor CI/CD and write some error handling code; all output was reviewed for correctness_