### PR TITLE
Delta frame trace

### DIFF
--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -590,7 +590,7 @@ impl BasePdr {
             }
 
             // Try to get counterexample relative to last frame
-            let res = match self.rel_ind(ctx, smt_ctx, sys, enc, cube, RelIndType::Extended)? {
+            let res = match self.rel_ind(ctx, smt_ctx, sys, enc, &obj, RelIndType::Extended)? {
                 (CheckSatResponse::Sat, Some(cube)) => Some(cube), // Extract counterexample-to-induction
                 (CheckSatResponse::Unsat, _) => None,
                 (CheckSatResponse::Unknown, _) => {
@@ -611,7 +611,7 @@ impl BasePdr {
                 worklist.push(obj);
             } else {
                 let mut test_cube = TimedCube {
-                    cube: cube.cube.clone(),
+                    cube: obj.cube.clone(),
                     frame: obj.frame.increment(),
                 };
 

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -422,20 +422,20 @@ impl BasePdr {
             // Special case: init frame is just activation literal for initial states
             self.init_frame
         } else {
-            // Get conjunction with all other frame activation literals negated
+            // Sanity check
+            assert!(frame_id <= self.frontier());
+
+            // Conjunct all blocked cubes in this frame and higher (since all blocked
+            // cubes in higher delta frames are also blocked in this frame)
             self.iter().fold(ctx.get_true(), |acc, id| {
-                if id == frame_id {
-                    // Include activation literals of target frame
+                if id >= frame_id {
+                    // Include activation literals of target frame and all higher frames,
+                    // which include cubes blocked in the `frame_id`-th frame
                     ctx.and(acc, self[id].act)
                 } else {
-                    // Avoid solver bloat/slowdown by "disabling" other activation literals
-                    //
-                    // Sound since the actual state space represented by the `frame_id`-th
-                    // frame is directly "activated" by `self[frame_id].act`. Allowing the solver
-                    // to explore activation for the other frames would be redundant (for the
-                    // upper frames) or unsound (for the lower frames)
-                    //
-                    // Note: must only "disable" lower frames once delta frames are implemented
+                    // Deactivate lower frames to preserve soundness,
+                    // since they represent overapproximations of reachable state
+                    // that are stronger than that of the `frame_id`-th frame
                     let neg_act = ctx.not(self[id].act);
                     ctx.and(acc, neg_act)
                 }
@@ -477,7 +477,7 @@ impl BasePdr {
         query(ctx, smt_ctx, sys, enc, assumptions)
     }
 
-    /// Add blocked cubes to preceding frames
+    /// Add blocked cube to the highest possible frame
     ///
     /// # Preconditions
     /// Input cube must be blocked at frame `cube.frame`
@@ -485,22 +485,27 @@ impl BasePdr {
         &mut self,
         ctx: &mut Context,
         smt_ctx: &mut impl SolverContext,
+        sys: &TransitionSystem,
         enc: &impl TransitionSystemEncoding,
         cube: &TimedCube,
     ) -> Result<()> {
-        // Get frontier index
-        let front = cube.frame;
+        let mut test_cube = cube.clone();
 
-        // Get frame identifiers up to and including front index
-        let ids = self
-            .iter()
-            .take_while(|id| id <= &front)
-            .collect::<Vec<_>>();
-
-        // Add new cube to all frames
-        for id in ids {
-            self[id].add_blocked_cube(ctx, smt_ctx, enc, &cube.cube)?;
+        // Push cube as far as possible in the frame trace
+        while test_cube.frame <= self.frontier()
+            && self
+                .rel_ind(ctx, smt_ctx, sys, enc, &test_cube, RelIndType::Extended)?
+                .0
+                == CheckSatResponse::Unsat
+        {
+            test_cube.frame = test_cube.frame.increment();
         }
+
+        // Sanity check for precondition violations
+        assert!(test_cube.frame > cube.frame);
+
+        // Add new cube to highest frame
+        self[test_cube.frame.decrement()].add_blocked_cube(ctx, smt_ctx, enc, &test_cube.cube)?;
 
         Ok(())
     }
@@ -623,7 +628,7 @@ impl BasePdr {
                 worklist.push(obj);
             } else {
                 // Refine frame trace with cube
-                self.add_blocked_cube(ctx, smt_ctx, enc, &obj)?;
+                self.add_blocked_cube(ctx, smt_ctx, sys, enc, &obj)?;
             }
         }
 
@@ -650,7 +655,8 @@ impl BasePdr {
 
         // Try to propagate blocked cubes in each frame forward
         for id in ids {
-            let mut num_left = self[id].cubes.len();
+            // Blocked cubes that cannot be propagated to the next frame
+            let mut retain = vec![];
 
             for cube_idx in 0..self[id].cubes.len() {
                 // Get cube
@@ -662,22 +668,29 @@ impl BasePdr {
                     frame: id.increment(),
                 };
 
-                // Check that cube is still blocked in next frame
-                if self
+                // Run query `SAT?[R_i /\ T /\ c]`, where `c` is the candidate cube
+                // for propagation
+                let smt_res = self
                     .rel_ind(ctx, smt_ctx, sys, enc, &query_cube, RelIndType::Standard)?
-                    .0
-                    == CheckSatResponse::Unsat
-                {
+                    .0;
+
+                // Check that cube is still blocked in next frame
+                if smt_res == CheckSatResponse::Unsat {
                     // Add blocked cube to next frame
                     self[id.increment()].add_blocked_cube(ctx, smt_ctx, enc, &cube)?;
-                    num_left -= 1;
+                } else {
+                    // Query must have been SAT or UNKNOWN: do not propagate to ensure soundness
+                    retain.push(cube);
                 }
             }
 
             // Check for inductive invariant: all clauses propagated
-            if num_left == 0 {
+            if retain.is_empty() {
                 return Ok(true);
             }
+
+            // Replace current frame with retained blocked cubes
+            self[id].cubes = retain;
         }
 
         // Inductive invariant not found
@@ -706,8 +719,10 @@ pub fn pdr(
     // Initialize PDR
     let mut state = BasePdr::init(ctx, smt_ctx, &enc, sys)?;
 
+    let limit = FrameId::Finite(NonZeroUsize::new(MAX_FRAMES).unwrap());
+
     // PDR loop
-    while state.frontier() <= FrameId::Finite(NonZeroUsize::new(MAX_FRAMES).unwrap()) {
+    while state.frontier() <= limit {
         // Try to get bad cube
         let bad_cube = state.get_bad_cube(ctx, smt_ctx, sys, &enc)?;
 

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -485,28 +485,11 @@ impl BasePdr {
         &mut self,
         ctx: &mut Context,
         smt_ctx: &mut impl SolverContext,
-        sys: &TransitionSystem,
         enc: &impl TransitionSystemEncoding,
         cube: &TimedCube,
     ) -> Result<()> {
-        let mut test_cube = cube.clone();
-
-        // Push cube as far as possible in the frame trace
-        while test_cube.frame <= self.frontier()
-            && self
-                .rel_ind(ctx, smt_ctx, sys, enc, &test_cube, RelIndType::Extended)?
-                .0
-                == CheckSatResponse::Unsat
-        {
-            test_cube.frame = test_cube.frame.increment();
-        }
-
-        // Sanity check for precondition violations
-        assert!(test_cube.frame > cube.frame);
-
         // Add new cube to highest frame
-        self[test_cube.frame.decrement()].add_blocked_cube(ctx, smt_ctx, enc, &test_cube.cube)?;
-
+        self[cube.frame].add_blocked_cube(ctx, smt_ctx, enc, &cube.cube)?;
         Ok(())
     }
 
@@ -627,8 +610,26 @@ impl BasePdr {
                 });
                 worklist.push(obj);
             } else {
+                let mut test_cube = TimedCube {
+                    cube: cube.cube.clone(),
+                    frame: obj.frame.increment(),
+                };
+
+                // Push cube as far as possible in the frame trace
+                while test_cube.frame <= self.frontier()
+                    && self
+                        .rel_ind(ctx, smt_ctx, sys, enc, &test_cube, RelIndType::Extended)?
+                        .0
+                        == CheckSatResponse::Unsat
+                {
+                    test_cube.frame = test_cube.frame.increment();
+                }
+
+                // Restore "working" frame
+                test_cube.frame = test_cube.frame.decrement();
+
                 // Refine frame trace with cube
-                self.add_blocked_cube(ctx, smt_ctx, sys, enc, &obj)?;
+                self.add_blocked_cube(ctx, smt_ctx, enc, &test_cube)?;
             }
         }
 

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -640,13 +640,7 @@ impl BasePdr {
 
         // Try to propagate blocked cubes in each frame forward
         for id in ids {
-            // Blocked cubes that cannot be propagated to the next frame
-            let mut retain = vec![];
-
-            for cube_idx in 0..self[id].cubes.len() {
-                // Get cube
-                let cube = self[id].cubes[cube_idx].clone();
-
+            for cube in std::mem::take(&mut self[id].cubes) {
                 // Get timed cube for relative inductiveness query
                 let query_cube = TimedCube {
                     cube,
@@ -665,17 +659,14 @@ impl BasePdr {
                     self[id.increment()].add_blocked_cube(ctx, smt_ctx, enc, query_cube.cube)?;
                 } else {
                     // Query must have been SAT or UNKNOWN: do not propagate to ensure soundness
-                    retain.push(query_cube.cube);
+                    self[id].cubes.push(query_cube.cube);
                 }
             }
 
             // Check for inductive invariant: all clauses propagated
-            if retain.is_empty() {
+            if self[id].cubes.is_empty() {
                 return Ok(true);
             }
-
-            // Replace current frame with retained blocked cubes
-            self[id].cubes = retain;
         }
 
         // Inductive invariant not found

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -477,22 +477,6 @@ impl BasePdr {
         query(ctx, smt_ctx, sys, enc, assumptions)
     }
 
-    /// Add blocked cube to the highest possible frame
-    ///
-    /// # Preconditions
-    /// Input cube must be blocked at frame `cube.frame`
-    fn add_blocked_cube(
-        &mut self,
-        ctx: &mut Context,
-        smt_ctx: &mut impl SolverContext,
-        enc: &impl TransitionSystemEncoding,
-        cube: TimedCube,
-    ) -> Result<()> {
-        // Add new cube to highest frame
-        self[cube.frame].add_blocked_cube(ctx, smt_ctx, enc, cube.cube)?;
-        Ok(())
-    }
-
     /// Frame identifier for frontier frame
     const fn frontier(&self) -> FrameId {
         if self.frames.is_empty() {
@@ -629,7 +613,7 @@ impl BasePdr {
                 test_cube.frame = test_cube.frame.decrement();
 
                 // Refine frame trace with cube
-                self.add_blocked_cube(ctx, smt_ctx, enc, test_cube)?;
+                self[cube.frame].add_blocked_cube(ctx, smt_ctx, enc, test_cube.cube)?;
             }
         }
 

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -297,7 +297,7 @@ impl Frame {
         ctx: &mut Context,
         smt_ctx: &mut impl SolverContext,
         enc: &impl TransitionSystemEncoding,
-        cube: &Cube,
+        cube: Cube,
     ) -> Result<()> {
         // Create implication act_i => \neg c, where c is the blocked cube stepped at current step
         let clause = cube.negate(ctx);
@@ -308,7 +308,7 @@ impl Frame {
         smt_ctx.assert(ctx, imp)?;
 
         // Add blocked cube to frame
-        self.cubes.push(cube.clone());
+        self.cubes.push(cube);
 
         Ok(())
     }
@@ -486,10 +486,10 @@ impl BasePdr {
         ctx: &mut Context,
         smt_ctx: &mut impl SolverContext,
         enc: &impl TransitionSystemEncoding,
-        cube: &TimedCube,
+        cube: TimedCube,
     ) -> Result<()> {
         // Add new cube to highest frame
-        self[cube.frame].add_blocked_cube(ctx, smt_ctx, enc, &cube.cube)?;
+        self[cube.frame].add_blocked_cube(ctx, smt_ctx, enc, cube.cube)?;
         Ok(())
     }
 
@@ -577,7 +577,7 @@ impl BasePdr {
         smt_ctx: &mut impl SolverContext,
         sys: &TransitionSystem,
         enc: &impl TransitionSystemEncoding,
-        cube: &TimedCube,
+        cube: TimedCube,
     ) -> Result<bool> {
         // Min-queue of proof obligations: start with initial proof obligation
         let mut worklist = BinaryHeap::from([cube.clone()]);
@@ -629,7 +629,7 @@ impl BasePdr {
                 test_cube.frame = test_cube.frame.decrement();
 
                 // Refine frame trace with cube
-                self.add_blocked_cube(ctx, smt_ctx, enc, &test_cube)?;
+                self.add_blocked_cube(ctx, smt_ctx, enc, test_cube)?;
             }
         }
 
@@ -678,7 +678,7 @@ impl BasePdr {
                 // Check that cube is still blocked in next frame
                 if smt_res == CheckSatResponse::Unsat {
                     // Add blocked cube to next frame
-                    self[id.increment()].add_blocked_cube(ctx, smt_ctx, enc, &cube)?;
+                    self[id.increment()].add_blocked_cube(ctx, smt_ctx, enc, cube)?;
                 } else {
                     // Query must have been SAT or UNKNOWN: do not propagate to ensure soundness
                     retain.push(cube);
@@ -734,7 +734,7 @@ pub fn pdr(
                 smt_ctx,
                 sys,
                 &enc,
-                &TimedCube {
+                TimedCube {
                     cube: bad,
                     frame: state.frontier(),
                 },

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -564,7 +564,7 @@ impl BasePdr {
         cube: TimedCube,
     ) -> Result<bool> {
         // Min-queue of proof obligations: start with initial proof obligation
-        let mut worklist = BinaryHeap::from([cube.clone()]);
+        let mut worklist = BinaryHeap::from([cube]);
 
         // Try to solve all proof obligations
         while let Some(obj) = worklist.pop() {
@@ -613,7 +613,7 @@ impl BasePdr {
                 test_cube.frame = test_cube.frame.decrement();
 
                 // Refine frame trace with cube
-                self[cube.frame].add_blocked_cube(ctx, smt_ctx, enc, test_cube.cube)?;
+                self[test_cube.frame].add_blocked_cube(ctx, smt_ctx, enc, test_cube.cube)?;
             }
         }
 
@@ -649,7 +649,7 @@ impl BasePdr {
 
                 // Get timed cube for relative inductiveness query
                 let query_cube = TimedCube {
-                    cube: cube.clone(),
+                    cube,
                     frame: id.increment(),
                 };
 
@@ -662,10 +662,10 @@ impl BasePdr {
                 // Check that cube is still blocked in next frame
                 if smt_res == CheckSatResponse::Unsat {
                     // Add blocked cube to next frame
-                    self[id.increment()].add_blocked_cube(ctx, smt_ctx, enc, cube)?;
+                    self[id.increment()].add_blocked_cube(ctx, smt_ctx, enc, query_cube.cube)?;
                 } else {
                     // Query must have been SAT or UNKNOWN: do not propagate to ensure soundness
-                    retain.push(cube);
+                    retain.push(query_cube.cube);
                 }
             }
 

--- a/patronus/tests/pdr.rs
+++ b/patronus/tests/pdr.rs
@@ -242,7 +242,6 @@ mod pdr {
         case_swap(&solver_from_env());
     }
 
-    #[ignore = "Cubes are not subsumed in PDR, leading to solver explosion"]
     #[test]
     fn test_aman_goel_4bit() {
         case_aman_goel_4bit(&solver_from_env());


### PR DESCRIPTION
# Changes
- `propagate_blocked_cubes` only retains blocked cubes in the current frame that are **NOT** propagated
- `frame_assumptions` now "activates" all frames that are >= target frame (since the cubes in the target frame could also be blocked in higher frames)
- `block_cube` pushes a blocked cube as far as possible in the frame trace before adding it to a frame (_informal rationale: cubes that were blocked earlier can actually help push this blocked cube further in the frame trace, preemptively propagating this cube and potentially helping to block other cubes; implemented in FMCAD'11 and Pono_)
- Fixed soundness bug in `block_cube` where cube blocking loop mistakenly used the original proof obligation instead of the current proof obligation

# Tests
All regression tests pass.