### PR TITLE
Added constraint support to PDR

### DIFF
--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -144,7 +144,7 @@ impl FrameId {
     /// If [`FrameId::Init`] is decremented
     fn decrement(self) -> Self {
         match self {
-            Self::Init => panic!("Cannot decrement init"),
+            Self::Init => panic!("cannot decrement init"),
             Self::Finite(n) => {
                 let fin = n.get() - 1;
 
@@ -395,6 +395,12 @@ impl BasePdr {
             }
         }
 
+        // Always assert constraints at current step
+        for &cons in &sys.constraints {
+            let cons_cur = expr_at_step(ctx, enc, cons, FROM_STEP);
+            smt_ctx.assert(ctx, cons_cur)?;
+        }
+
         // Initial frame activation literal
         let init_act = ctx.bv_symbol(format!("{ACT_LIT_PREFIX}init").as_str(), 1);
 
@@ -502,6 +508,13 @@ impl BasePdr {
             let neg_cube_cur = expr_at_step(ctx, enc, neg_cube_expr, FROM_STEP);
             assumptions.push(neg_cube_cur);
         }
+
+        // Assert constraints hold after transition
+        assumptions.extend(
+            sys.constraints
+                .iter()
+                .map(|&c| expr_at_step(ctx, enc, c, TO_STEP)),
+        );
 
         // Run SMT query
         query(ctx, smt_ctx, sys, enc, assumptions)
@@ -721,13 +734,23 @@ impl BasePdr {
             let cube_expr = cube.to_expr(ctx);
             let cube_next = expr_at_step(ctx, enc, cube_expr, TO_STEP);
 
+            // Post-transition constraint assertions
+            let cons_next = sys
+                .constraints
+                .iter()
+                .map(|&c| expr_at_step(ctx, enc, c, TO_STEP))
+                .collect::<Vec<_>>();
+            let cons_expr = cons_next
+                .iter()
+                .fold(ctx.get_true(), |acc, &e| ctx.and(acc, e));
+
             // Run the query `SAT?[R_\infty /\ \neg c /\ T /\ c']`
             let smt_res = query(
                 ctx,
                 smt_ctx,
                 sys,
                 enc,
-                vec![inf_assumption, clause_cur, cube_next],
+                vec![inf_assumption, clause_cur, cube_next, cons_expr],
             )?
             .0;
 
@@ -755,9 +778,6 @@ pub fn pdr(
         (r, None) => return Ok(r),
         (_, Some(enc)) => enc,
     };
-
-    // TODO: take care of constraints later
-    assert!(sys.constraints.is_empty());
 
     // Initialize two-step variables in solver
     enc.init_at(ctx, smt_ctx, FROM_STEP)?;

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -322,7 +322,7 @@ impl Frame {
 /// Frame trace maintained by vanilla PDR
 struct BasePdr {
     /// `TO_STEP` constraints
-    cons_next: ExprRef,
+    to_step_constraints: ExprRef,
 
     /// Initial frame
     init_frame: ExprRef,
@@ -443,7 +443,7 @@ impl BasePdr {
         };
 
         Ok(Self {
-            cons_next: cons_act,
+            to_step_constraints: cons_act,
             init_frame: init_act,
             inf_frame,
             frames: vec![], // Index consistency taken care by indexing function
@@ -532,7 +532,7 @@ impl BasePdr {
         }
 
         // Assert constraints hold after transition
-        assumptions.push(self.cons_next);
+        assumptions.push(self.to_step_constraints);
 
         // Run SMT query
         query(ctx, smt_ctx, sys, enc, assumptions)
@@ -581,7 +581,7 @@ impl BasePdr {
         let front_assumption = self.frame_assumptions(ctx, front);
 
         // Turn off constraint requirements for `TO_STEP`
-        let neg_cons = ctx.not(self.cons_next);
+        let neg_cons = ctx.not(self.to_step_constraints);
 
         // Run query SAT?[R_N /\ \neg P]
         match query(
@@ -768,7 +768,12 @@ impl BasePdr {
                 smt_ctx,
                 sys,
                 enc,
-                vec![inf_assumption, clause_cur, cube_next, self.cons_next],
+                vec![
+                    inf_assumption,
+                    clause_cur,
+                    cube_next,
+                    self.to_step_constraints,
+                ],
             )?
             .0;
 

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -398,24 +398,22 @@ impl BasePdr {
             }
         }
 
-        // Next step constraints
-        let mut cons_next_lits = vec![];
-
         // Always assert constraints at current step
         for &cons in &sys.constraints {
             let cons_cur = expr_at_step(ctx, enc, cons, FROM_STEP);
-            let cons_next = expr_at_step(ctx, enc, cons, TO_STEP);
-
             smt_ctx.assert(ctx, cons_cur)?;
-            cons_next_lits.push(cons_next);
         }
 
         // Next step constraint activation literal
         let cons_act = ctx.bv_symbol(format!("{ACT_LIT_PREFIX}nxt_cons").as_str(), 1);
 
-        let cons_next_expr = cons_next_lits
+        let cons_next_expr = sys
+            .constraints
             .iter()
-            .fold(ctx.get_true(), |acc, &c| ctx.and(acc, c));
+            .map(|&c| expr_at_step(ctx, enc, c, TO_STEP))
+            .collect::<Vec<_>>()
+            .into_iter()
+            .fold(ctx.get_true(), |acc, c| ctx.and(acc, c));
         let cons_imp = ctx.implies(cons_act, cons_next_expr);
 
         // Permanently assert in solver

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -322,7 +322,7 @@ impl Frame {
 /// Frame trace maintained by vanilla PDR
 struct BasePdr {
     /// `TO_STEP` constraints
-    to_step_constraints: ExprRef,
+    to_step_constraints_active: ExprRef,
 
     /// Initial frame
     init_frame: ExprRef,
@@ -443,7 +443,7 @@ impl BasePdr {
         };
 
         Ok(Self {
-            to_step_constraints: cons_act,
+            to_step_constraints_active: cons_act,
             init_frame: init_act,
             inf_frame,
             frames: vec![], // Index consistency taken care by indexing function
@@ -532,7 +532,7 @@ impl BasePdr {
         }
 
         // Assert constraints hold after transition
-        assumptions.push(self.to_step_constraints);
+        assumptions.push(self.to_step_constraints_active);
 
         // Run SMT query
         query(ctx, smt_ctx, sys, enc, assumptions)
@@ -581,7 +581,7 @@ impl BasePdr {
         let front_assumption = self.frame_assumptions(ctx, front);
 
         // Turn off constraint requirements for `TO_STEP`
-        let neg_cons = ctx.not(self.to_step_constraints);
+        let neg_cons = ctx.not(self.to_step_constraints_active);
 
         // Run query SAT?[R_N /\ \neg P]
         match query(
@@ -772,7 +772,7 @@ impl BasePdr {
                     inf_assumption,
                     clause_cur,
                     cube_next,
-                    self.to_step_constraints,
+                    self.to_step_constraints_active,
                 ],
             )?
             .0;

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -321,6 +321,9 @@ impl Frame {
 
 /// Frame trace maintained by vanilla PDR
 struct BasePdr {
+    /// `TO_STEP` constraints
+    cons_next: ExprRef,
+
     /// Initial frame
     init_frame: ExprRef,
 
@@ -395,11 +398,29 @@ impl BasePdr {
             }
         }
 
+        // Next step constraints
+        let mut cons_next_lits = vec![];
+
         // Always assert constraints at current step
         for &cons in &sys.constraints {
             let cons_cur = expr_at_step(ctx, enc, cons, FROM_STEP);
+            let cons_next = expr_at_step(ctx, enc, cons, TO_STEP);
+
             smt_ctx.assert(ctx, cons_cur)?;
+            cons_next_lits.push(cons_next);
         }
+
+        // Next step constraint activation literal
+        let cons_act = ctx.bv_symbol(format!("{ACT_LIT_PREFIX}nxt_cons").as_str(), 1);
+
+        let cons_next_expr = cons_next_lits
+            .iter()
+            .fold(ctx.get_true(), |acc, &c| ctx.and(acc, c));
+        let cons_imp = ctx.implies(cons_act, cons_next_expr);
+
+        // Permanently assert in solver
+        smt_ctx.declare_const(ctx, cons_act)?;
+        smt_ctx.assert(ctx, cons_imp)?;
 
         // Initial frame activation literal
         let init_act = ctx.bv_symbol(format!("{ACT_LIT_PREFIX}init").as_str(), 1);
@@ -407,11 +428,11 @@ impl BasePdr {
         // Create act_0 => init_cube, where init_cube is stepped to the before step
         let init_expr = init_cube.to_expr(ctx);
         let init_expr = expr_at_step(ctx, enc, init_expr, FROM_STEP);
-        let imp = ctx.implies(init_act, init_expr);
+        let init_imp = ctx.implies(init_act, init_expr);
 
         // Permanently assert implication in solver
         smt_ctx.declare_const(ctx, init_act)?;
-        smt_ctx.assert(ctx, imp)?;
+        smt_ctx.assert(ctx, init_imp)?;
 
         // Create infinite frame
         let inf_act = ctx.bv_symbol(format!("{ACT_LIT_PREFIX}inf").as_str(), 1);
@@ -422,6 +443,7 @@ impl BasePdr {
         };
 
         Ok(Self {
+            cons_next: cons_act,
             init_frame: init_act,
             inf_frame,
             frames: vec![], // Index consistency taken care by indexing function
@@ -510,11 +532,7 @@ impl BasePdr {
         }
 
         // Assert constraints hold after transition
-        assumptions.extend(
-            sys.constraints
-                .iter()
-                .map(|&c| expr_at_step(ctx, enc, c, TO_STEP)),
-        );
+        assumptions.push(self.cons_next);
 
         // Run SMT query
         query(ctx, smt_ctx, sys, enc, assumptions)
@@ -562,8 +580,17 @@ impl BasePdr {
         // Get frame assumptions for frontier frame
         let front_assumption = self.frame_assumptions(ctx, front);
 
+        // Turn off constraint requirements for `TO_STEP`
+        let neg_cons = ctx.not(self.cons_next);
+
         // Run query SAT?[R_N /\ \neg P]
-        match query(ctx, smt_ctx, sys, enc, vec![front_assumption, bad_expr])? {
+        match query(
+            ctx,
+            smt_ctx,
+            sys,
+            enc,
+            vec![front_assumption, bad_expr, neg_cons],
+        )? {
             (CheckSatResponse::Sat, Some(cube)) => {
                 // Safety property violation found: return witness cube
                 Ok(Some(cube))
@@ -734,23 +761,14 @@ impl BasePdr {
             let cube_expr = cube.to_expr(ctx);
             let cube_next = expr_at_step(ctx, enc, cube_expr, TO_STEP);
 
-            // Post-transition constraint assertions
-            let cons_next = sys
-                .constraints
-                .iter()
-                .map(|&c| expr_at_step(ctx, enc, c, TO_STEP))
-                .collect::<Vec<_>>();
-            let cons_expr = cons_next
-                .iter()
-                .fold(ctx.get_true(), |acc, &e| ctx.and(acc, e));
-
-            // Run the query `SAT?[R_\infty /\ \neg c /\ T /\ c']`
+            // Run the query `SAT?[R_\infty /\ \neg c /\ T /\ c']`, asserting that the
+            // constraints hold at `TO_STEP`
             let smt_res = query(
                 ctx,
                 smt_ctx,
                 sys,
                 enc,
-                vec![inf_assumption, clause_cur, cube_next, cons_expr],
+                vec![inf_assumption, clause_cur, cube_next, self.cons_next],
             )?
             .0;
 

--- a/patronus/tests/pdr.rs
+++ b/patronus/tests/pdr.rs
@@ -193,6 +193,36 @@ fn case_simple_fail(solver: &SmtLibSolver) {
     }
 }
 
+fn case_quiz1_sat(solver: &SmtLibSolver) {
+    let (ctx, sys, res) = run_pdr_file(solver, "../inputs/chiseltest/Quiz1.btor", None);
+
+    if let ModelCheckResult::Fail(wit) = res {
+        validate_witness(&ctx, &sys, &wit);
+    } else {
+        panic!("test_simple_fail failed");
+    }
+}
+
+fn case_quiz2_sat(solver: &SmtLibSolver) {
+    let (ctx, sys, res) = run_pdr_file(solver, "../inputs/chiseltest/Quiz2.sat.btor", None);
+
+    if let ModelCheckResult::Fail(wit) = res {
+        validate_witness(&ctx, &sys, &wit);
+    } else {
+        panic!("test_simple_fail failed");
+    }
+}
+
+fn case_quiz4_sat(solver: &SmtLibSolver) {
+    let (ctx, sys, res) = run_pdr_file(solver, "../inputs/chiseltest/Quiz4.sat.btor", None);
+
+    if let ModelCheckResult::Fail(wit) = res {
+        validate_witness(&ctx, &sys, &wit);
+    } else {
+        panic!("test_simple_fail failed");
+    }
+}
+
 fn case_delay(solver: &SmtLibSolver) {
     let (_, _, res) = run_pdr_file(solver, "../inputs/verilog_tests/Delay.btor", None);
     assert!(matches!(res, ModelCheckResult::Success));
@@ -205,6 +235,21 @@ fn case_swap(solver: &SmtLibSolver) {
 
 fn case_aman_goel_4bit(solver: &SmtLibSolver) {
     let (_, _, res) = run_pdr_file(solver, "../inputs/unittest/aman_goel_4bit.btor", None);
+    assert!(matches!(res, ModelCheckResult::Success));
+}
+
+fn case_quiz1_unsat(solver: &SmtLibSolver) {
+    let (_, _, res) = run_pdr_file(solver, "../inputs/chiseltest/Quiz1.unsat.btor", None);
+    assert!(matches!(res, ModelCheckResult::Success));
+}
+
+fn case_quiz2_unsat(solver: &SmtLibSolver) {
+    let (_, _, res) = run_pdr_file(solver, "../inputs/chiseltest/Quiz2.unsat.btor", None);
+    assert!(matches!(res, ModelCheckResult::Success));
+}
+
+fn case_quiz4_unsat(solver: &SmtLibSolver) {
+    let (_, _, res) = run_pdr_file(solver, "../inputs/chiseltest/Quiz4.unsat.btor", None);
     assert!(matches!(res, ModelCheckResult::Success));
 }
 
@@ -232,6 +277,22 @@ mod pdr {
         case_simple_fail(&solver_from_env());
     }
 
+    #[ignore = "Need blocked cube generalization"]
+    #[test]
+    fn test_quiz1_sat() {
+        case_quiz1_sat(&solver_from_env());
+    }
+
+    #[test]
+    fn test_quiz2_sat() {
+        case_quiz2_sat(&solver_from_env());
+    }
+
+    #[test]
+    fn test_quiz4_sat() {
+        case_quiz4_sat(&solver_from_env());
+    }
+
     #[test]
     fn test_delay() {
         case_delay(&solver_from_env());
@@ -245,5 +306,22 @@ mod pdr {
     #[test]
     fn test_aman_goel_4bit() {
         case_aman_goel_4bit(&solver_from_env());
+    }
+
+    #[test]
+    fn test_quiz1_unsat() {
+        case_quiz1_unsat(&solver_from_env());
+    }
+
+    #[ignore = "Need blocked cube generalization"]
+    #[test]
+    fn test_quiz2_unsat() {
+        case_quiz2_unsat(&solver_from_env());
+    }
+
+    #[ignore = "Need blocked cube generalization"]
+    #[test]
+    fn test_quiz4_unsat() {
+        case_quiz4_unsat(&solver_from_env());
     }
 }


### PR DESCRIPTION
# Changes
- Always assert constraints at `FROM_STEP` 
- Assert constraints for `TO_STEP` in `rel_ind` and infinite frame propagation steps
- Added new `inputs/chiseltest` tests with constraints

# Soundness

## Frame Trace Invariant (**HOLDS FOR VANILLA PDR WITHOUT GENERALIZATION**)

All blocked cubes in the frame trace must satisfy the constraints.

## Asserting Constraints at `FROM_STEP`

We examine all three cases:
1. In `get_bad_cube`, we must always assume that the frontier frame (stepped at `FROM_STEP`) satisfies the constraints. Otherwise, we may yield a bad cube that violates the constraints, leading to unsoundness.
2. In `rel_ind`, we must always assert that the previous frame $\mathbf{R}_{i - 1}$ satisfies the constraints. Otherwise, an extracted model can violate the constraints and cause unsoundness.
3. In `propagate_blocked_cubes`, we apply similar reasoning to the second case with regards to propagating finite frame blocked cubes to the infinite frame.

## Asserting Constraints at `TO_STEP`

We first assert that asserting constraints at `TO_STEP` is **UNSOUND** in `get_bad_cube`. To do this, consider the following counterexample:

Suppose we have the circuit

```verilog
module Counter(input clk);
// Counter register
reg [1:0] count = 2'd0;

// Main logic
always @(posedge clk) begin
  count <= count + 2'd1;
end

// Formal assertions
always @(*) begin
  // Constraint
  assume(count != 2'd2);
  
  // Safety property
  assert(count != 2'd1);
end
endmodule
```

In this case, $\mathbf{R}_0$ trivially satisfies the safety property. However, at $\mathbf{R}_1$, a concrete counterexample could simply be `count == 2'd1`. However, since $\mathbf{T}$ is permanently asserted and we constrain the next state to be `count != 2'd2`, the solver would not find this true counterexample. Therefore, PDR would falsely prove the safety property here.

However, we assert that asserting constraints at `TO_STEP` is sound for the other cases:

1. All calls to `rel_ind` are either made on blocked cubes in the frame trace (which must satisfy the invariant) or extracted models from previous `rel_ind` calls must satisfy constraints (by construction).
2. Similar reasoning as the first case, but with the propagation of finite frame blocked cubes to the infinite frame.

# Tests

All regression tests pass. Some tests (`Quiz1.btor`, `Quiz2.unsat.btor`, `Quiz4.unsat.btor`) have been skipped since they hang when run. This is probably due to PDR trying to individually block concrete values of a 16-bit register, which leads to many SMT queries that slow down execution. The most important fix for this issue should be blocked cube generalization.