### PR TITLE
Refactor BMC encoding, add stepped expression cache, and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "Readme.md"
 license = "BSD-3-Clause"
 rust-version = "1.88.0"
 # used by main patronus library and python bindings
-version = "0.38.1"
+version = "0.39.0"
 
 [workspace.dependencies]
 rustc-hash = "2.*"

--- a/patronus/src/mc.rs
+++ b/patronus/src/mc.rs
@@ -3,12 +3,12 @@
 // author: Kevin Laeufer <laeufer@berkeley.edu>
 
 mod bmc;
+mod encoding;
 mod pdr;
 mod types;
+mod utils;
 
-pub use bmc::{
-    ModelCheckResult, TransitionSystemEncoding, UnrollSmtEncoding, bmc, check_assuming,
-    check_assuming_end, get_smt_value,
-};
+pub use bmc::bmc;
 pub use pdr::pdr;
-pub use types::{InitValue, Witness};
+pub use types::{InitValue, ModelCheckResult, Witness};
+pub use utils::get_smt_value;

--- a/patronus/src/mc/bmc.rs
+++ b/patronus/src/mc/bmc.rs
@@ -4,15 +4,15 @@
 // author: Kevin Laeufer <laeufer@cornell.edu>
 
 use crate::expr::*;
+use crate::mc::ModelCheckResult;
 use crate::mc::Witness;
-use crate::mc::types::InitValue;
+use crate::mc::encoding::{TransitionSystemEncoding, UnrollSmtEncoding};
+use crate::mc::types::{InitValue, Result};
+use crate::mc::utils::{check_assuming, check_assuming_end, get_smt_value};
 use crate::smt::*;
-use crate::system::analysis::{Uses, analyze_for_serialization, count_system_expr_uses};
-use crate::system::{State, TransitionSystem};
+use crate::system::TransitionSystem;
+use crate::system::analysis::count_system_expr_uses;
 use baa::*;
-use rustc_hash::{FxHashMap, FxHashSet};
-
-type Result<T> = crate::smt::Result<T>;
 
 /// Runs up to [k_max] steps of BMC.
 ///
@@ -49,7 +49,7 @@ pub fn bmc(
     for k in 0..=k_max {
         // assume all constraints hold in this step
         for expr_ref in constraints.iter() {
-            let expr = enc.get_at(ctx, *expr_ref, k);
+            let expr = enc.step_at(ctx, *expr_ref, k);
             smt_ctx.assert(ctx, expr)?;
         }
 
@@ -66,7 +66,7 @@ pub fn bmc(
 
         if check_bad_states_individually {
             for expr_ref in bad_states.iter() {
-                let expr = enc.get_at(ctx, *expr_ref, k);
+                let expr = enc.step_at(ctx, *expr_ref, k);
                 let res = check_assuming(ctx, smt_ctx, [expr])?;
 
                 // count expression uses
@@ -80,7 +80,7 @@ pub fn bmc(
         } else {
             let all_bads = bad_states
                 .iter()
-                .map(|expr_ref| enc.get_at(ctx, *expr_ref, k))
+                .map(|expr_ref| enc.step_at(ctx, *expr_ref, k))
                 .collect::<Vec<_>>();
             let any_bad = all_bads.into_iter().reduce(|a, b| ctx.or(a, b)).unwrap();
             let res = check_assuming(ctx, smt_ctx, [any_bad])?;
@@ -146,7 +146,7 @@ fn get_witness(
 
     // which bad states did we hit?
     for (bad_idx, expr) in bad_states.iter().enumerate() {
-        let sym_at = enc.get_at(ctx, *expr, k_max);
+        let sym_at = enc.step_at(ctx, *expr, k_max);
         let value = get_smt_value(ctx, smt_ctx, sym_at)?;
         let value = match value {
             Value::Array(_) => unreachable!("should always be a bitvector!"),
@@ -160,7 +160,7 @@ fn get_witness(
 
     // collect initial values
     for (state_cnt, state) in sys.states.iter().enumerate() {
-        let sym_at = enc.get_at(ctx, state.symbol, 0);
+        let sym_at = enc.step_at(ctx, state.symbol, 0);
         let value = get_smt_value(ctx, smt_ctx, sym_at)?;
         // we assume that state ids are monotonically increasing with +1
         assert_eq!(wit.init.len(), state_cnt);
@@ -190,7 +190,7 @@ fn get_witness(
     for k in 0..=k_max {
         let mut input_values = Vec::default();
         for input in sys.inputs.iter() {
-            let sym_at = enc.get_at(ctx, *input, k);
+            let sym_at = enc.step_at(ctx, *input, k);
             let value = get_smt_value(ctx, smt_ctx, sym_at)?;
             input_values.push(Some(value));
         }
@@ -198,350 +198,4 @@ fn get_witness(
     }
 
     Ok(wit)
-}
-
-#[inline]
-pub fn check_assuming(
-    ctx: &Context,
-    smt_ctx: &mut impl SolverContext,
-    props: impl IntoIterator<Item = ExprRef>,
-) -> Result<CheckSatResponse> {
-    if smt_ctx.supports_check_assuming() {
-        smt_ctx.check_sat_assuming(ctx, props)
-    } else {
-        smt_ctx.push()?; // add new assertion
-        for prop in props.into_iter() {
-            smt_ctx.assert(ctx, prop)?;
-        }
-        let res = smt_ctx.check_sat()?;
-        Ok(res)
-    }
-}
-
-// pops context for solver that do not support check assuming
-#[inline]
-pub fn check_assuming_end(smt_ctx: &mut impl SolverContext) -> Result<()> {
-    if !smt_ctx.supports_check_assuming() {
-        smt_ctx.pop()
-    } else {
-        Ok(())
-    }
-}
-
-pub fn get_smt_value(
-    ctx: &mut Context,
-    smt_ctx: &mut impl SolverContext,
-    expr: ExprRef,
-) -> Result<Value> {
-    let value_expr = smt_ctx.get_value(ctx, expr)?;
-    let value = eval_expr(ctx, &FxHashMap::default(), value_expr);
-    Ok(value)
-}
-
-pub enum ModelCheckResult {
-    Success,
-    Unknown,
-    Fail(Witness),
-}
-
-pub trait TransitionSystemEncoding {
-    fn define_header(&self, smt_ctx: &mut impl SolverContext) -> Result<()>;
-    fn init_at(
-        &mut self,
-        ctx: &mut Context,
-        smt_ctx: &mut impl SolverContext,
-        step: u64,
-    ) -> Result<()>;
-    fn unroll(&mut self, ctx: &mut Context, smt_ctx: &mut impl SolverContext) -> Result<()>;
-    /// Allows access to inputs, states, constraints and bad_state expressions.
-    fn get_at(&self, ctx: &Context, expr: ExprRef, k: u64) -> ExprRef;
-}
-
-pub struct UnrollSmtEncoding {
-    /// the offset at which our encoding was initialized
-    offset: Option<u64>,
-    current_step: Option<u64>,
-    /// all signals that need to be serialized separately, in the correct order
-    signal_order: Vec<ExprRef>,
-    /// look up table to see if an expression is a reference
-    signals: Vec<Option<SmtSignalInfo>>,
-    /// system states
-    states: Vec<State>,
-    /// symbols of signals at every step
-    symbols_at: Vec<Vec<ExprRef>>,
-}
-
-#[derive(Clone)]
-struct SmtSignalInfo {
-    /// monotonically increasing unique id
-    id: u16,
-    name: StringRef,
-    uses: Uses,
-    is_state: bool,
-    is_input: bool,
-    /// denotes states that do not change and thus can be represented by a single symbol
-    is_const: bool,
-}
-
-impl UnrollSmtEncoding {
-    pub fn new(ctx: &mut Context, sys: &TransitionSystem, include_outputs: bool) -> Self {
-        let ser_info = analyze_for_serialization(ctx, sys, include_outputs);
-        let max_ser_index: usize = ser_info
-            .signal_order
-            .iter()
-            .map(|s| s.expr.into())
-            .max()
-            .unwrap_or_default();
-        let max_state_index: usize = sys
-            .states
-            .iter()
-            .map(|s| s.symbol.into())
-            .max()
-            .unwrap_or_default();
-        let signals_map_len = std::cmp::max(max_ser_index, max_state_index) + 1;
-        let mut signals = vec![None; signals_map_len];
-        let mut signal_order = Vec::with_capacity(ser_info.signal_order.len());
-
-        let is_state: FxHashSet<ExprRef> =
-            FxHashSet::from_iter(sys.states.iter().map(|s| s.symbol));
-
-        // we skip states in our signal order since they are not calculated directly in the update function
-        let input_set = FxHashSet::from_iter(sys.inputs.iter().cloned());
-        for (id, root) in ser_info
-            .signal_order
-            .into_iter()
-            .filter(|r| !is_state.contains(&r.expr))
-            .enumerate()
-        {
-            signal_order.push(root.expr);
-            let name = sys.names[root.expr].unwrap_or({
-                let default_name = format!("__n{}", usize::from(root.expr));
-                ctx.string(default_name.into())
-            });
-            let is_input = input_set.contains(&root.expr);
-            let info = SmtSignalInfo {
-                id: id as u16,
-                name,
-                uses: root.uses,
-                is_state: false,
-                is_input,
-                is_const: false,
-            };
-            signals[usize::from(root.expr)] = Some(info);
-        }
-        for (id, state) in sys.states.iter().enumerate() {
-            let id = (id + signal_order.len()) as u16;
-            let info = SmtSignalInfo {
-                id,
-                name: ctx[state.symbol].get_symbol_name_ref().unwrap(),
-                uses: Uses::default(), // irrelevant
-                is_state: true,
-                is_input: false,
-                is_const: state.is_const(),
-            };
-            signals[usize::from(state.symbol)] = Some(info);
-        }
-        let current_step = None;
-        let offset = None;
-        let states = sys.states.clone();
-
-        Self {
-            offset,
-            current_step,
-            signals,
-            signal_order,
-            states,
-            symbols_at: Vec::new(),
-        }
-    }
-
-    fn define_signals(
-        &self,
-        ctx: &mut Context,
-        smt_ctx: &mut impl SolverContext,
-        step: u64,
-        filter: &impl Fn(&SmtSignalInfo) -> bool,
-    ) -> Result<()> {
-        for expr in self.signal_order.iter() {
-            let info = self.signals[usize::from(*expr)].as_ref().unwrap();
-            if info.is_state {
-                continue;
-            }
-            let skip = !filter(info);
-            if !skip {
-                let tpe = expr.get_type(ctx);
-                let name = ctx.string(name_at(&ctx[info.name], step).into());
-                let symbol_at = ctx.symbol(name, tpe);
-                if ctx[*expr].is_symbol() {
-                    smt_ctx.declare_const(ctx, symbol_at)?;
-                } else {
-                    let value = self.expr_in_step(ctx, *expr, step);
-                    smt_ctx.define_const(ctx, symbol_at, value)?;
-                }
-            }
-        }
-        Ok(())
-    }
-
-    fn create_signal_symbols_in_step(&mut self, ctx: &mut Context, step: u64) {
-        let offset = self.offset.expect("Need to call init_at first!");
-        let index = (step - offset) as usize;
-        assert_eq!(self.symbols_at.len(), index, "Missing or duplicate step!");
-        let mut syms = Vec::with_capacity(self.signal_order.len());
-        for &signal in self
-            .signal_order
-            .iter()
-            .chain(self.states.iter().map(|s| &s.symbol))
-        {
-            let info = self.signals[usize::from(signal)].as_ref().unwrap();
-            let name_ref = if info.is_const {
-                info.name
-            } else {
-                let name = name_at(&ctx[info.name], step);
-                ctx.string(name.into())
-            };
-            let tpe = signal.get_type(ctx);
-            debug_assert_eq!(info.id as usize, syms.len());
-            syms.push(ctx.symbol(name_ref, tpe));
-        }
-        self.symbols_at.push(syms);
-    }
-
-    fn signal_sym_in_step(&self, expr: ExprRef, step: u64) -> Option<ExprRef> {
-        if let Some(Some(info)) = self.signals.get(usize::from(expr)) {
-            let offset = self.offset.expect("Need to call init_at first!");
-            let index = (step - offset) as usize;
-            Some(self.symbols_at[index][info.id as usize])
-        } else {
-            None
-        }
-    }
-
-    fn expr_in_step(&self, ctx: &mut Context, expr: ExprRef, step: u64) -> ExprRef {
-        let expr_is_symbol = ctx[expr].is_symbol();
-        simple_transform_expr(ctx, expr, |_, e, _| {
-            // If the expression we are trying to serialize is not a symbol, then wo
-            // do not just want to replace it with one, as that would lead us to a tautology!
-            if !expr_is_symbol && e == expr {
-                None
-            } else {
-                self.signal_sym_in_step(e, step)
-            }
-        })
-    }
-}
-
-impl TransitionSystemEncoding for UnrollSmtEncoding {
-    fn define_header(&self, _smt_ctx: &mut impl SolverContext) -> Result<()> {
-        // nothing to do in this encoding
-        Ok(())
-    }
-
-    fn init_at(
-        &mut self,
-        ctx: &mut Context,
-        smt_ctx: &mut impl SolverContext,
-        step: u64,
-    ) -> Result<()> {
-        // delete old mutable state
-        self.symbols_at.clear();
-        // remember current step and starting offset
-        self.current_step = Some(step);
-        self.offset = Some(step);
-        self.create_signal_symbols_in_step(ctx, step);
-
-        if step == 0 {
-            // define signals that are used to calculate init expressions
-            self.define_signals(ctx, smt_ctx, 0, &|info: &SmtSignalInfo| info.uses.init > 0)?;
-        }
-
-        // declare/define initial states
-        for state in self.states.iter() {
-            let symbol_at = if state.is_const() {
-                state.symbol
-            } else {
-                let base_name = ctx.get_symbol_name(state.symbol).unwrap();
-                let name = ctx.string(name_at(base_name, step).into());
-                let tpe = state.symbol.get_type(ctx);
-                ctx.symbol(name, tpe)
-            };
-
-            match (step, state.init) {
-                (0, Some(value)) => {
-                    let value_at = self.expr_in_step(ctx, value, step);
-                    smt_ctx.define_const(ctx, symbol_at, value_at)?;
-                }
-                _ => {
-                    smt_ctx.declare_const(ctx, symbol_at)?;
-                }
-            }
-        }
-
-        // define other signals including inputs, init signals are never needed here
-        self.define_signals(ctx, smt_ctx, step, &|info: &SmtSignalInfo| {
-            (info.uses.other > 0 || info.is_input) && (info.uses.init == 0)
-        })?;
-
-        Ok(())
-    }
-
-    fn unroll(&mut self, ctx: &mut Context, smt_ctx: &mut impl SolverContext) -> Result<()> {
-        let prev_step = self.current_step.unwrap();
-        let next_step = prev_step + 1;
-        self.create_signal_symbols_in_step(ctx, next_step);
-
-        // define next state signals for previous state
-        self.define_signals(ctx, smt_ctx, prev_step, &|info: &SmtSignalInfo| {
-            info.uses.next > 0 && info.uses.other == 0 && !info.is_input
-        })?;
-
-        // define next state
-        for state in self.states.iter() {
-            let name = name_at(ctx.get_symbol_name(state.symbol).unwrap(), next_step);
-            let name = ctx.string(name.into());
-            let tpe = state.symbol.get_type(ctx);
-            let symbol_at = ctx.symbol(name, tpe);
-            match state.next {
-                Some(value) => {
-                    // constant states never change from their initial value
-                    if !state.is_const() {
-                        let value = self.expr_in_step(ctx, value, prev_step);
-                        smt_ctx.define_const(ctx, symbol_at, value)?;
-                    }
-                }
-                None => {
-                    smt_ctx.declare_const(ctx, symbol_at)?;
-                }
-            }
-        }
-
-        // define other signals and inputs
-        // we always define all inputs, even if they are only used in the "next" expression
-        // since our witness extraction relies on them being available
-        self.define_signals(ctx, smt_ctx, next_step, &|info: &SmtSignalInfo| {
-            info.uses.other > 0 || info.is_input
-        })?;
-
-        // update step count
-        self.current_step = Some(next_step);
-        Ok(())
-    }
-
-    fn get_at(&self, ctx: &Context, expr: ExprRef, step: u64) -> ExprRef {
-        assert!(step <= self.current_step.unwrap_or(0));
-        self.signal_sym_in_step(expr, step).unwrap_or_else(|| {
-            if ctx[expr].is_true() || ctx[expr].is_false() {
-                expr
-            } else {
-                panic!(
-                    "Failed to find signal {} in step {step}",
-                    expr.serialize_to_str(ctx)
-                )
-            }
-        })
-    }
-}
-
-fn name_at(name: &str, step: u64) -> String {
-    format!("{}@{}", name, step)
 }

--- a/patronus/src/mc/encoding.rs
+++ b/patronus/src/mc/encoding.rs
@@ -1,0 +1,324 @@
+use crate::expr::{
+    Context, ExprRef, SerializableIrNode, StringRef, TypeCheck, simple_transform_expr,
+};
+use crate::mc::types::Result;
+use crate::smt::SolverContext;
+use crate::system::analysis::{Uses, analyze_for_serialization};
+use crate::system::{State, TransitionSystem};
+use rustc_hash::FxHashSet;
+
+pub type Step = u64;
+
+pub trait TransitionSystemEncoding {
+    fn define_header(&self, smt_ctx: &mut impl SolverContext) -> Result<()>;
+    fn init_at(
+        &mut self,
+        ctx: &mut Context,
+        smt_ctx: &mut impl SolverContext,
+        step: u64,
+    ) -> Result<()>;
+    fn unroll(&mut self, ctx: &mut Context, smt_ctx: &mut impl SolverContext) -> Result<()>;
+    /// Step SMT expression
+    fn step_at(&self, ctx: &mut Context, expr: ExprRef, k: Step) -> ExprRef;
+}
+
+pub struct UnrollSmtEncoding {
+    /// the offset at which our encoding was initialized
+    offset: Option<u64>,
+    current_step: Option<Step>,
+    /// all signals that need to be serialized separately, in the correct order
+    signal_order: Vec<ExprRef>,
+    /// look up table to see if an expression is a reference
+    signals: Vec<Option<SmtSignalInfo>>,
+    /// system states
+    states: Vec<State>,
+    /// symbols of signals at every step
+    symbols_at: Vec<Vec<ExprRef>>,
+}
+
+#[derive(Clone)]
+struct SmtSignalInfo {
+    /// monotonically increasing unique id
+    id: u16,
+    name: StringRef,
+    uses: Uses,
+    is_state: bool,
+    is_input: bool,
+    /// denotes states that do not change and thus can be represented by a single symbol
+    is_const: bool,
+}
+
+impl UnrollSmtEncoding {
+    pub fn new(ctx: &mut Context, sys: &TransitionSystem, include_outputs: bool) -> Self {
+        let ser_info = analyze_for_serialization(ctx, sys, include_outputs);
+        let max_ser_index: usize = ser_info
+            .signal_order
+            .iter()
+            .map(|s| s.expr.into())
+            .max()
+            .unwrap_or_default();
+        let max_state_index: usize = sys
+            .states
+            .iter()
+            .map(|s| s.symbol.into())
+            .max()
+            .unwrap_or_default();
+        let signals_map_len = std::cmp::max(max_ser_index, max_state_index) + 1;
+        let mut signals = vec![None; signals_map_len];
+        let mut signal_order = Vec::with_capacity(ser_info.signal_order.len());
+
+        let is_state: FxHashSet<ExprRef> =
+            FxHashSet::from_iter(sys.states.iter().map(|s| s.symbol));
+
+        // we skip states in our signal order since they are not calculated directly in the update function
+        let input_set = FxHashSet::from_iter(sys.inputs.iter().cloned());
+        for (id, root) in ser_info
+            .signal_order
+            .into_iter()
+            .filter(|r| !is_state.contains(&r.expr))
+            .enumerate()
+        {
+            signal_order.push(root.expr);
+            let name = sys.names[root.expr].unwrap_or({
+                let default_name = format!("__n{}", usize::from(root.expr));
+                ctx.string(default_name.into())
+            });
+            let is_input = input_set.contains(&root.expr);
+            let info = SmtSignalInfo {
+                id: id as u16,
+                name,
+                uses: root.uses,
+                is_state: false,
+                is_input,
+                is_const: false,
+            };
+            signals[usize::from(root.expr)] = Some(info);
+        }
+        for (id, state) in sys.states.iter().enumerate() {
+            let id = (id + signal_order.len()) as u16;
+            let info = SmtSignalInfo {
+                id,
+                name: ctx[state.symbol].get_symbol_name_ref().unwrap(),
+                uses: Uses::default(), // irrelevant
+                is_state: true,
+                is_input: false,
+                is_const: state.is_const(),
+            };
+            signals[usize::from(state.symbol)] = Some(info);
+        }
+        let current_step = None;
+        let offset = None;
+        let states = sys.states.clone();
+
+        Self {
+            offset,
+            current_step,
+            signals,
+            signal_order,
+            states,
+            symbols_at: Vec::new(),
+        }
+    }
+
+    fn define_signals(
+        &self,
+        ctx: &mut Context,
+        smt_ctx: &mut impl SolverContext,
+        step: Step,
+        filter: &impl Fn(&SmtSignalInfo) -> bool,
+    ) -> Result<()> {
+        for expr in self.signal_order.iter() {
+            let info = self.signals[usize::from(*expr)].as_ref().unwrap();
+            if info.is_state {
+                continue;
+            }
+            let skip = !filter(info);
+            if !skip {
+                let tpe = expr.get_type(ctx);
+                let name = ctx.string(name_at(&ctx[info.name], step).into());
+                let symbol_at = ctx.symbol(name, tpe);
+                if ctx[*expr].is_symbol() {
+                    smt_ctx.declare_const(ctx, symbol_at)?;
+                } else {
+                    let value = self.expr_in_step(ctx, *expr, step);
+                    smt_ctx.define_const(ctx, symbol_at, value)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn create_signal_symbols_in_step(&mut self, ctx: &mut Context, step: Step) {
+        let offset = self.offset.expect("Need to call init_at first!");
+        let index = (step - offset) as usize;
+        assert_eq!(self.symbols_at.len(), index, "Missing or duplicate step!");
+        let mut syms = Vec::with_capacity(self.signal_order.len());
+        for &signal in self
+            .signal_order
+            .iter()
+            .chain(self.states.iter().map(|s| &s.symbol))
+        {
+            let info = self.signals[usize::from(signal)].as_ref().unwrap();
+            let name_ref = if info.is_const {
+                info.name
+            } else {
+                let name = name_at(&ctx[info.name], step);
+                ctx.string(name.into())
+            };
+            let tpe = signal.get_type(ctx);
+            debug_assert_eq!(info.id as usize, syms.len());
+            syms.push(ctx.symbol(name_ref, tpe));
+        }
+        self.symbols_at.push(syms);
+    }
+
+    fn signal_sym_in_step(&self, expr: ExprRef, step: Step) -> Option<ExprRef> {
+        if let Some(Some(info)) = self.signals.get(usize::from(expr)) {
+            let offset = self.offset.expect("Need to call init_at first!");
+            let index = (step - offset) as usize;
+            Some(self.symbols_at[index][info.id as usize])
+        } else {
+            None
+        }
+    }
+
+    fn expr_in_step(&self, ctx: &mut Context, expr: ExprRef, step: Step) -> ExprRef {
+        let expr_is_symbol = ctx[expr].is_symbol();
+        simple_transform_expr(ctx, expr, |_, e, _| {
+            // If the expression we are trying to serialize is not a symbol, then wo
+            // do not just want to replace it with one, as that would lead us to a tautology!
+            if !expr_is_symbol && e == expr {
+                None
+            } else {
+                self.signal_sym_in_step(e, step)
+            }
+        })
+    }
+}
+
+impl TransitionSystemEncoding for UnrollSmtEncoding {
+    fn define_header(&self, _smt_ctx: &mut impl SolverContext) -> Result<()> {
+        // nothing to do in this encoding
+        Ok(())
+    }
+
+    fn init_at(
+        &mut self,
+        ctx: &mut Context,
+        smt_ctx: &mut impl SolverContext,
+        step: Step,
+    ) -> Result<()> {
+        // delete old mutable state
+        self.symbols_at.clear();
+        // remember current step and starting offset
+        self.current_step = Some(step);
+        self.offset = Some(step);
+        self.create_signal_symbols_in_step(ctx, step);
+
+        if step == 0 {
+            // define signals that are used to calculate init expressions
+            self.define_signals(ctx, smt_ctx, 0, &|info: &SmtSignalInfo| info.uses.init > 0)?;
+        }
+
+        // declare/define initial states
+        for state in self.states.iter() {
+            let symbol_at = if state.is_const() {
+                state.symbol
+            } else {
+                let base_name = ctx.get_symbol_name(state.symbol).unwrap();
+                let name = ctx.string(name_at(base_name, step).into());
+                let tpe = state.symbol.get_type(ctx);
+                ctx.symbol(name, tpe)
+            };
+
+            match (step, state.init) {
+                (0, Some(value)) => {
+                    let value_at = self.expr_in_step(ctx, value, step);
+                    smt_ctx.define_const(ctx, symbol_at, value_at)?;
+                }
+                _ => {
+                    smt_ctx.declare_const(ctx, symbol_at)?;
+                }
+            }
+        }
+
+        // define other signals including inputs, init signals are never needed here
+        self.define_signals(ctx, smt_ctx, step, &|info: &SmtSignalInfo| {
+            (info.uses.other > 0 || info.is_input) && (info.uses.init == 0)
+        })?;
+
+        Ok(())
+    }
+
+    fn unroll(&mut self, ctx: &mut Context, smt_ctx: &mut impl SolverContext) -> Result<()> {
+        let prev_step = self.current_step.unwrap();
+        let next_step = prev_step + 1;
+        self.create_signal_symbols_in_step(ctx, next_step);
+
+        // define next state signals for previous state
+        self.define_signals(ctx, smt_ctx, prev_step, &|info: &SmtSignalInfo| {
+            info.uses.next > 0 && info.uses.other == 0 && !info.is_input
+        })?;
+
+        // define next state
+        for state in self.states.iter() {
+            let name = name_at(ctx.get_symbol_name(state.symbol).unwrap(), next_step);
+            let name = ctx.string(name.into());
+            let tpe = state.symbol.get_type(ctx);
+            let symbol_at = ctx.symbol(name, tpe);
+            match state.next {
+                Some(value) => {
+                    // constant states never change from their initial value
+                    if !state.is_const() {
+                        let value = self.expr_in_step(ctx, value, prev_step);
+                        smt_ctx.define_const(ctx, symbol_at, value)?;
+                    }
+                }
+                None => {
+                    smt_ctx.declare_const(ctx, symbol_at)?;
+                }
+            }
+        }
+
+        // define other signals and inputs
+        // we always define all inputs, even if they are only used in the "next" expression
+        // since our witness extraction relies on them being available
+        self.define_signals(ctx, smt_ctx, next_step, &|info: &SmtSignalInfo| {
+            info.uses.other > 0 || info.is_input
+        })?;
+
+        // update step count
+        self.current_step = Some(next_step);
+        Ok(())
+    }
+
+    fn step_at(&self, ctx: &mut Context, expr: ExprRef, k: Step) -> ExprRef {
+        assert!(k <= self.current_step.unwrap_or(0));
+
+        self.signal_sym_in_step(expr, k).unwrap_or_else(|| {
+            if ctx[expr].is_true() || ctx[expr].is_false() {
+                // If expression is a simple constant, return it
+                expr
+            } else if ctx[expr].is_symbol() {
+                // If expression is itself an atomic symbol, it could not be found
+                panic!(
+                    "Failed to find signal {} in step {k}",
+                    expr.serialize_to_str(ctx)
+                );
+            } else {
+                // `expr` must be compound expression: recursively step all symbols
+                simple_transform_expr(ctx, expr, |ctx, e, _| {
+                    if ctx[e].is_symbol() {
+                        Some(self.step_at(ctx, e, k))
+                    } else {
+                        None
+                    }
+                })
+            }
+        })
+    }
+}
+
+fn name_at(name: &str, step: Step) -> String {
+    format!("{}@{}", name, step)
+}

--- a/patronus/src/mc/encoding.rs
+++ b/patronus/src/mc/encoding.rs
@@ -5,7 +5,8 @@ use crate::mc::types::Result;
 use crate::smt::SolverContext;
 use crate::system::analysis::{Uses, analyze_for_serialization};
 use crate::system::{State, TransitionSystem};
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::cell::RefCell;
 
 pub type Step = u64;
 
@@ -34,6 +35,8 @@ pub struct UnrollSmtEncoding {
     states: Vec<State>,
     /// symbols of signals at every step
     symbols_at: Vec<Vec<ExprRef>>,
+    /// memo table for previously stepped expressions
+    expr_cache: RefCell<FxHashMap<(ExprRef, Step), ExprRef>>,
 }
 
 #[derive(Clone)]
@@ -117,6 +120,7 @@ impl UnrollSmtEncoding {
             signal_order,
             states,
             symbols_at: Vec::new(),
+            expr_cache: RefCell::new(FxHashMap::default()),
         }
     }
 
@@ -215,6 +219,9 @@ impl TransitionSystemEncoding for UnrollSmtEncoding {
         self.offset = Some(step);
         self.create_signal_symbols_in_step(ctx, step);
 
+        // Clear old stepped expression cache
+        self.expr_cache.borrow_mut().clear();
+
         if step == 0 {
             // define signals that are used to calculate init expressions
             self.define_signals(ctx, smt_ctx, 0, &|info: &SmtSignalInfo| info.uses.init > 0)?;
@@ -295,25 +302,35 @@ impl TransitionSystemEncoding for UnrollSmtEncoding {
     fn step_at(&self, ctx: &mut Context, expr: ExprRef, k: Step) -> ExprRef {
         assert!(k <= self.current_step.unwrap_or(0));
 
+        if let Some(&e) = self.expr_cache.borrow().get(&(expr, k)) {
+            // If stepped expression exists in cache, just return it
+            return e;
+        }
+
         self.signal_sym_in_step(expr, k).unwrap_or_else(|| {
             if ctx[expr].is_true() || ctx[expr].is_false() {
                 // If expression is a simple constant, return it
                 expr
             } else if ctx[expr].is_symbol() {
-                // If expression is itself an atomic symbol, it could not be found
+                // If expression is itself an atomic symbol and was not found, error out
                 panic!(
                     "Failed to find signal {} in step {k}",
                     expr.serialize_to_str(ctx)
                 );
             } else {
                 // `expr` must be compound expression: recursively step all symbols
-                simple_transform_expr(ctx, expr, |ctx, e, _| {
+                let stepped_expr = simple_transform_expr(ctx, expr, |ctx, e, _| {
                     if ctx[e].is_symbol() {
                         Some(self.step_at(ctx, e, k))
                     } else {
                         None
                     }
-                })
+                });
+
+                // Cache stepped expression
+                self.expr_cache.borrow_mut().insert((expr, k), stepped_expr);
+
+                stepped_expr
             }
         })
     }

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -214,17 +214,15 @@ fn get_bit_level_cube(
                 // Get bitvector width
                 let width = bv.width();
 
-                // Iterate through all bits of the bitvector
-                // and assign bit-level equalities to concrete value
+                // Iterate through all bits of the bitvector and assert correct bit value
                 for idx in 0..width {
                     let bit = ctx.slice(sym, idx, idx);
-                    let bit_val = if bv.is_bit_set(idx) {
-                        ctx.get_true()
+                    let lit = if bv.is_bit_set(idx) {
+                        bit
                     } else {
-                        ctx.get_false()
+                        ctx.not(bit)
                     };
 
-                    let lit = ctx.equal(bit, bit_val);
                     literals.push(lit);
                 }
             }

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -4,18 +4,16 @@
 
 use crate::expr::*;
 use crate::mc::bmc::start_bmc_or_pdr;
-use crate::mc::{
-    ModelCheckResult, TransitionSystemEncoding, bmc, check_assuming, check_assuming_end,
-    get_smt_value,
-};
+use crate::mc::encoding::{Step, TransitionSystemEncoding};
+use crate::mc::types::Result;
+use crate::mc::utils::{check_assuming, check_assuming_end, get_smt_value};
+use crate::mc::{ModelCheckResult, bmc};
 use crate::smt::*;
 use crate::system::TransitionSystem;
 use baa::{BitVecOps, Value};
 use std::collections::BinaryHeap;
 use std::num::NonZeroUsize;
 use std::ops::{Index, IndexMut};
-
-type Step = u64;
 
 const FROM_STEP: Step = 1;
 
@@ -164,25 +162,6 @@ impl FrameId {
 // PDR helper functions
 // -------------------------------------------------------------------------------------------------
 
-/// Get the stepped version of an SMT expression
-///
-/// # Preconditions
-/// * `expr` must exist in `enc` at `step`
-fn expr_at_step(
-    ctx: &mut Context,
-    enc: &impl TransitionSystemEncoding,
-    expr: ExprRef,
-    step: Step,
-) -> ExprRef {
-    simple_transform_expr(ctx, expr, |ctx, e, _| {
-        if ctx[e].is_symbol() {
-            Some(enc.get_at(ctx, e, step))
-        } else {
-            None
-        }
-    })
-}
-
 /// Extract states values from solver at a certain time step
 ///
 /// # Preconditions
@@ -202,7 +181,7 @@ fn extract_state_values(
 
     // Extract exact SMT value for each system state
     for state in &sys.states {
-        let sym = enc.get_at(ctx, state.symbol, step);
+        let sym = enc.step_at(ctx, state.symbol, step);
         state_vals.push((state.symbol, get_smt_value(ctx, smt_ctx, sym)?));
     }
 
@@ -306,7 +285,7 @@ impl Frame {
     ) -> Result<()> {
         // Create implication act_i => \neg c, where c is the blocked cube stepped at current step
         let clause = cube.negate(ctx);
-        let clause_expr = expr_at_step(ctx, enc, clause, FROM_STEP);
+        let clause_expr = enc.step_at(ctx, clause, FROM_STEP);
         let imp = ctx.implies(self.act, clause_expr);
 
         // Permanently assert implication in solver
@@ -400,7 +379,7 @@ impl BasePdr {
 
         // Always assert constraints at current step
         for &cons in &sys.constraints {
-            let cons_cur = expr_at_step(ctx, enc, cons, FROM_STEP);
+            let cons_cur = enc.step_at(ctx, cons, FROM_STEP);
             smt_ctx.assert(ctx, cons_cur)?;
         }
 
@@ -410,7 +389,7 @@ impl BasePdr {
         let cons_next_expr = sys
             .constraints
             .iter()
-            .map(|&c| expr_at_step(ctx, enc, c, TO_STEP))
+            .map(|&c| enc.step_at(ctx, c, TO_STEP))
             .collect::<Vec<_>>()
             .into_iter()
             .fold(ctx.get_true(), |acc, c| ctx.and(acc, c));
@@ -425,7 +404,7 @@ impl BasePdr {
 
         // Create act_0 => init_cube, where init_cube is stepped to the before step
         let init_expr = init_cube.to_expr(ctx);
-        let init_expr = expr_at_step(ctx, enc, init_expr, FROM_STEP);
+        let init_expr = enc.step_at(ctx, init_expr, FROM_STEP);
         let init_imp = ctx.implies(init_act, init_expr);
 
         // Permanently assert implication in solver
@@ -519,13 +498,13 @@ impl BasePdr {
 
         // Next step cube
         let cube_expr = cube.cube.to_expr(ctx);
-        let cube_next = expr_at_step(ctx, enc, cube_expr, TO_STEP);
+        let cube_next = enc.step_at(ctx, cube_expr, TO_STEP);
         assumptions.push(cube_next);
 
         // Current step negation cube
         if query_type == RelIndType::Extended {
             let neg_cube_expr = cube.cube.negate(ctx);
-            let neg_cube_cur = expr_at_step(ctx, enc, neg_cube_expr, FROM_STEP);
+            let neg_cube_cur = enc.step_at(ctx, neg_cube_expr, FROM_STEP);
             assumptions.push(neg_cube_cur);
         }
 
@@ -567,7 +546,7 @@ impl BasePdr {
         let bad_lits: Vec<ExprRef> = sys
             .bad_states
             .iter()
-            .map(|&b| expr_at_step(ctx, enc, b, FROM_STEP))
+            .map(|&b| enc.step_at(ctx, b, FROM_STEP))
             .collect();
 
         // Disjunct all bad state literals
@@ -754,10 +733,10 @@ impl BasePdr {
             let inf_assumption = self.frame_assumptions(ctx, FrameId::Infinite);
 
             let clause_expr = cube.negate(ctx);
-            let clause_cur = expr_at_step(ctx, enc, clause_expr, FROM_STEP);
+            let clause_cur = enc.step_at(ctx, clause_expr, FROM_STEP);
 
             let cube_expr = cube.to_expr(ctx);
-            let cube_next = expr_at_step(ctx, enc, cube_expr, TO_STEP);
+            let cube_next = enc.step_at(ctx, cube_expr, TO_STEP);
 
             // Run the query `SAT?[R_\infty /\ \neg c /\ T /\ c']`, asserting that the
             // constraints hold at `TO_STEP`

--- a/patronus/src/mc/types.rs
+++ b/patronus/src/mc/types.rs
@@ -20,7 +20,7 @@ pub enum InitValue {
 impl TryFrom<InitValue> for Value {
     type Error = ();
 
-    fn try_from(value: InitValue) -> std::result::Result<baa::Value, ()> {
+    fn try_from(value: InitValue) -> std::result::Result<Self, ()> {
         match value {
             InitValue::BitVec(v) => Ok(Value::BitVec(v)),
             InitValue::Array(v, _) => Ok(Value::Array(v)),

--- a/patronus/src/mc/types.rs
+++ b/patronus/src/mc/types.rs
@@ -5,6 +5,8 @@
 
 use baa::Value;
 
+pub type Result<T> = crate::smt::Result<T>;
+
 #[derive(Debug, Clone, Default)]
 pub enum InitValue {
     BitVec(baa::BitVecValue),
@@ -18,7 +20,7 @@ pub enum InitValue {
 impl TryFrom<InitValue> for Value {
     type Error = ();
 
-    fn try_from(value: InitValue) -> Result<Self, Self::Error> {
+    fn try_from(value: InitValue) -> std::result::Result<baa::Value, ()> {
         match value {
             InitValue::BitVec(v) => Ok(Value::BitVec(v)),
             InitValue::Array(v, _) => Ok(Value::Array(v)),
@@ -40,4 +42,10 @@ pub struct Witness {
     pub input_names: Vec<Option<String>>,
     /// Index of all safety properties (bad state predicates) that are violated by this witness.
     pub failed_safety: Vec<u32>,
+}
+
+pub enum ModelCheckResult {
+    Success,
+    Unknown,
+    Fail(Witness),
 }

--- a/patronus/src/mc/utils.rs
+++ b/patronus/src/mc/utils.rs
@@ -1,0 +1,43 @@
+use crate::expr::{Context, ExprRef, eval_expr};
+use crate::mc::types::Result;
+use crate::smt::{CheckSatResponse, SolverContext};
+use baa::Value;
+use rustc_hash::FxHashMap;
+
+#[inline]
+pub fn check_assuming(
+    ctx: &Context,
+    smt_ctx: &mut impl SolverContext,
+    props: impl IntoIterator<Item = ExprRef>,
+) -> Result<CheckSatResponse> {
+    if smt_ctx.supports_check_assuming() {
+        smt_ctx.check_sat_assuming(ctx, props)
+    } else {
+        smt_ctx.push()?; // add new assertion
+        for prop in props.into_iter() {
+            smt_ctx.assert(ctx, prop)?;
+        }
+        let res = smt_ctx.check_sat()?;
+        Ok(res)
+    }
+}
+
+// pops context for solver that do not support check assuming
+#[inline]
+pub fn check_assuming_end(smt_ctx: &mut impl SolverContext) -> Result<()> {
+    if !smt_ctx.supports_check_assuming() {
+        smt_ctx.pop()
+    } else {
+        Ok(())
+    }
+}
+
+pub fn get_smt_value(
+    ctx: &mut Context,
+    smt_ctx: &mut impl SolverContext,
+    expr: ExprRef,
+) -> Result<Value> {
+    let value_expr = smt_ctx.get_value(ctx, expr)?;
+    let value = eval_expr(ctx, &FxHashMap::default(), value_expr);
+    Ok(value)
+}


### PR DESCRIPTION
# Changes

- Fixed #35 by removing `expr_at_step` and factoring its logic into a new `UnrollSmtEncoding` function `step_at`, which compounds the old `get_at` behavior with signals/constants and `expr_at_step` behavior with compound SMT expressions
- Added internal stepped expression cache to `UnrollSmtEncoding` for memoizing stepped compound expressions, reducing the need for expensive recursive calls for repeat expression steps
- Fixed #36
- Refactored all `TransitionSystemEncoding` and `UnrollSmtEncoding` code into separate file (`encoding.rs`)
- Refactored all `check_assuming`, `check_assuming_end`, and `get_smt_value` code into separate file (`utils.rs`)
- Refactored `ModelCheckResult` into `types.rs`
- Slimmed down public interface for `mc` crate to only functions/enums that are truly used by external modules

# Testing

All regression tests pass.