### PR TITLE
Add cube fixing for UNSAT core and enable passing tests

### DIFF
--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -614,6 +614,9 @@ impl BasePdr {
     /// "Fix" generalized cube by restoring enough removed literals until non-intersection
     /// with initial states
     ///
+    /// Follows implementation by Stanford Pono (<https://github.com/stanford-centaur/pono/blob/main/engines/ic3base.cpp#L929>)
+    /// and SMT-Switch (<https://github.com/stanford-centaur/smt-switch/blob/main/src/utils.cpp#L993>)
+    ///
     /// # Errors
     /// Returns [`Error::UnexpectedResponse`] if any SMT query returns `UNKNOWN` or original cube
     /// truly intersects the initial states
@@ -790,8 +793,7 @@ impl BasePdr {
             let gen_lits = genr
                 .literals
                 .iter()
-                .filter(|e| lit_map.contains_key(e))
-                .map(|e| lit_map[e])
+                .filter_map(|&lit| lit_map.get(&lit).copied())
                 .collect::<FxHashSet<_>>();
 
             // Literals not in UNSAT core

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -930,7 +930,13 @@ impl BasePdr {
         // Try to solve all proof obligations
         while let Some(obj) = worklist.pop() {
             // If proof obligation intersects with initial states, blocking fails
-            if obj.frame == FrameId::Init {
+            let cube_expr = obj.cube.to_expr(ctx);
+            let cube_from = self.enc.expr_at_step(ctx, cube_expr, FROM_STEP);
+            if obj.frame == FrameId::Init
+                || self
+                    .intersects_init(ctx, smt_ctx, sys, [cube_from], false)?
+                    .0
+            {
                 return Ok(false);
             }
 

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -11,7 +11,7 @@ use crate::mc::{
 use crate::smt::*;
 use crate::system::TransitionSystem;
 use baa::{BitVecOps, Value};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::BinaryHeap;
 use std::num::NonZeroUsize;
 use std::ops::{Index, IndexMut};
@@ -611,6 +611,115 @@ impl BasePdr {
         }
     }
 
+    /// "Fix" generalized cube by restoring enough removed literals until non-intersection
+    /// with initial states
+    ///
+    /// # Errors
+    /// Returns [`Error::UnexpectedResponse`] if any SMT query returns `UNKNOWN` or original cube
+    /// truly intersects the initial states
+    fn fix_gen_cube(
+        &mut self,
+        ctx: &mut Context,
+        smt_ctx: &mut impl SolverContext,
+        sys: &TransitionSystem,
+        gen_cube: Cube,
+        rm_lits: impl IntoIterator<Item = ExprRef>,
+    ) -> Result<Cube> {
+        // If generalized cube already doesn't intersect with initial states, just return
+        let cube_expr = gen_cube.to_expr(ctx);
+        let cube_from = self.enc.expr_at_step(ctx, cube_expr, FROM_STEP);
+        if !self
+            .intersects_init(ctx, smt_ctx, sys, [cube_from], false)?
+            .0
+        {
+            return Ok(gen_cube);
+        }
+
+        // Create activation literals for original cube literals (predicates) that were
+        // dropped during generalization
+        let mut lit_map = FxHashMap::default();
+        for lit in rm_lits {
+            // Create activation literal implication
+            let act = self.create_act_lit(ctx, smt_ctx)?;
+            let expr_from = self.enc.expr_at_step(ctx, lit, FROM_STEP);
+            let imp = ctx.implies(act, expr_from);
+
+            // Assert in solver
+            smt_ctx.assert(ctx, imp)?;
+
+            // Add mapping
+            lit_map.insert(act, lit);
+        }
+
+        // Flag for first iteration
+        let mut first_iter = true;
+
+        // Original generalized cube at `FROM_STEP`
+        let cube_expr = gen_cube.to_expr(ctx);
+        let cube_from = self.enc.expr_at_step(ctx, cube_expr, FROM_STEP);
+
+        loop {
+            // Gather activation literals of original cube literals that could be dropped
+            let mut assumps = lit_map.keys().copied().collect::<Vec<_>>();
+
+            // Add original generalized cube to assumption
+            assumps.push(cube_from);
+
+            let check_res = self.intersects_init(ctx, smt_ctx, sys, assumps, true)?;
+
+            if check_res.0 && first_iter {
+                // Clean up activation literals
+                for &act in lit_map.keys() {
+                    let neg_act = ctx.not(act);
+                    smt_ctx.assert(ctx, neg_act)?;
+                }
+
+                // If first iteration, original cube must truly intersect with init frame
+                return Err(Error::UnexpectedResponse(
+                    "`fix_gen_cube` in `BasePdr`".into(),
+                    "original cube intersects with init".into(),
+                ));
+            }
+
+            // All removed literals should not be in UNSAT core
+            assert!(!check_res.0);
+
+            // Store previous number of literals
+            let prev_acts = lit_map.keys().copied().collect::<Vec<_>>();
+
+            // Collect all literals in the UNSAT core
+            let ex_cube = check_res.1.unwrap();
+            let gen_lits = ex_cube.literals.iter().collect::<FxHashSet<_>>();
+
+            // Remove all candidate literals not in UNSAT core
+            lit_map.retain(|e, _| gen_lits.contains(e));
+
+            // Permanently disable literals that were removed
+            for &act in &prev_acts {
+                if !lit_map.contains_key(&act) {
+                    let neg_act = ctx.not(act);
+                    smt_ctx.assert(ctx, neg_act)?;
+                }
+            }
+
+            if lit_map.len() == prev_acts.len() {
+                // If no literals are removed, then fixpoint reached
+                let mut fin_lits = gen_cube.literals;
+                fin_lits.extend(lit_map.values().copied());
+
+                // Clean up activation literals
+                for &act in lit_map.keys() {
+                    let neg_act = ctx.not(act);
+                    smt_ctx.assert(ctx, neg_act)?;
+                }
+
+                return Ok(Cube { literals: fin_lits });
+            }
+
+            first_iter = false;
+        }
+    }
+
     /// Run relative inductiveness query
     /// (i.e. `SAT?[R_{i - 1} /\ \neg c /\ T c']`)
     ///
@@ -677,30 +786,28 @@ impl BasePdr {
         let res = if smt_res.0 == CheckSatResponse::Unsat
             && let Some(genr) = smt_res.1
         {
-            // Get literals from UNSAT core that are in the candidate cube
+            // Literals in UNSAT core
             let gen_lits = genr
                 .literals
                 .iter()
-                .filter_map(|lit| lit_map.get(lit).copied())
+                .filter(|e| lit_map.contains_key(e))
+                .map(|e| lit_map[e])
+                .collect::<FxHashSet<_>>();
+
+            // Literals not in UNSAT core
+            let rm_lits = lit_map
+                .values()
+                .copied()
+                .filter(|e| !gen_lits.contains(e))
                 .collect::<Vec<_>>();
 
-            let gen_cube = Cube { literals: gen_lits };
+            // Make generalized cube not intersect initial states
+            let gen_cube = Cube {
+                literals: gen_lits.into_iter().collect(),
+            };
+            let fixed = self.fix_gen_cube(ctx, smt_ctx, sys, gen_cube, rm_lits)?;
 
-            // Step cube as expression at `FROM_STEP`
-            let gen_expr = gen_cube.to_expr(ctx);
-            let gen_from = self.enc.expr_at_step(ctx, gen_expr, FROM_STEP);
-
-            if self
-                .intersects_init(ctx, smt_ctx, sys, [gen_from], false)?
-                .0
-            {
-                // Generalized cube intersects with the initial states; adding it to the
-                // frame trace would be unsound
-                // Instead, return the original cube
-                Ok((CheckSatResponse::Unsat, Some(cube.cube.clone())))
-            } else {
-                Ok((CheckSatResponse::Unsat, Some(gen_cube)))
-            }
+            Ok((CheckSatResponse::Unsat, Some(fixed)))
         } else {
             Ok(smt_res)
         };

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -930,13 +930,7 @@ impl BasePdr {
         // Try to solve all proof obligations
         while let Some(obj) = worklist.pop() {
             // If proof obligation intersects with initial states, blocking fails
-            let cube_expr = obj.cube.to_expr(ctx);
-            let cube_from = self.enc.expr_at_step(ctx, cube_expr, FROM_STEP);
-            if obj.frame == FrameId::Init
-                || self
-                    .intersects_init(ctx, smt_ctx, sys, [cube_from], false)?
-                    .0
-            {
+            if obj.frame == FrameId::Init {
                 return Ok(false);
             }
 

--- a/patronus/tests/pdr.rs
+++ b/patronus/tests/pdr.rs
@@ -421,7 +421,6 @@ mod pdr {
         case_simple_fail_no_gen(&solver_from_env());
     }
 
-    #[ignore = "Need `fix_gen_cube` to pass"]
     #[test]
     fn test_quiz1_sat() {
         case_quiz1_sat(&solver_from_env());
@@ -432,7 +431,6 @@ mod pdr {
         case_quiz2_sat(&solver_from_env());
     }
 
-    #[ignore = "Need `fix_gen_cube` to pass"]
     #[test]
     fn test_quiz4_sat() {
         case_quiz4_sat(&solver_from_env());
@@ -474,13 +472,11 @@ mod pdr {
         case_quiz1_unsat(&solver_from_env());
     }
 
-    #[ignore = "Need `fix_gen_cube` to pass"]
     #[test]
     fn test_quiz2_unsat() {
         case_quiz2_unsat(&solver_from_env());
     }
 
-    #[ignore = "Need `fix_gen_cube` to pass"]
     #[test]
     fn test_quiz4_unsat() {
         case_quiz4_unsat(&solver_from_env());


### PR DESCRIPTION
# Changes

- Added `fix_gen_cube` method to add literals back to UNSAT-core generalized cubes until non-intersection with initial states
- Un-ignored tests that previously hanged when UNSAT-core generalized cubes intersected with the initial states and had to be discarded

# Testing

All tests pass.