### PR TITLE
Add vanilla array support for PDR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,8 +58,86 @@ jobs:
       env:
         PATRONUS_TEST_SOLVER: ${{ matrix.solver }}
 
-  mc:
-    name: Test MC Tool
+  pdr:
+    name: Test MC Tool with PDR
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+        solver:
+          - bitwuzla
+          - cvc5
+          - z3
+        engine:
+          - pdr
+
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set Up Z3
+        if: ${{ matrix.solver == 'z3' }}
+        uses: ./.github/workflows/setup-z3
+        with:
+          version: ${{ env.Z3_VERSION }}
+      - name: Set Up CVC5
+        if: ${{ matrix.solver == 'cvc5' }}
+        uses: ./.github/workflows/setup-cvc5
+        with:
+          version: ${{ env.CVC5_VERSION }}
+      - name: Set Up Yices
+        if: ${{ matrix.solver == 'yices2' }}
+        uses: ./.github/workflows/setup-yices
+        with:
+          version: ${{ env.YICES_VERSION }}
+      - name: Set Up Bitwuzla
+        if: ${{ matrix.solver == 'bitwuzla' }}
+        uses: ./.github/workflows/setup-bitwuzla
+        with:
+          version: ${{ env.BITWUZLA_VERSION }}
+      - name: Install btor sim
+        run: |
+          mkdir /tmp/btor
+          cd /tmp/btor
+          git clone https://github.com/hwmcc/btor2tools.git
+          cd btor2tools
+          ./configure.sh
+          cd build
+          make
+          echo "/tmp/btor/btor2tools/build/bin/" >> "$GITHUB_PATH"
+      - name: Update Rust to ${{ matrix.toolchain }}
+        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - name: Build
+        run: cargo build --verbose --release -p mc
+      - name: mc Quiz1
+        run: |
+          cargo run --release -p mc -- --engine=${{ matrix.engine }} --solver=${{ matrix.solver }} inputs/chiseltest/Quiz1.btor > Quiz1.wit
+          btorsim inputs/chiseltest/Quiz1.btor Quiz1.wit
+      - name: mc Quiz1 (with additional assumption)
+        run: |
+          cargo run --release -p mc -- --engine=${{ matrix.engine }} --solver=${{ matrix.solver }} inputs/chiseltest/Quiz1.unsat.btor
+      - name: mc const array example
+        if: ${{ matrix.solver != 'yices2' }} # yices2 returns memory values that cannot be parsed
+        run: |
+          cargo run --release -p mc -- --engine=${{ matrix.engine }} --solver=${{ matrix.solver }} inputs/chiseltest/const_array_example.btor > const_array_example.wit
+          btorsim inputs/chiseltest/const_array_example.btor const_array_example.wit
+      - name: mc Quiz2
+        run: |
+          cargo run --release -p mc -- --engine=${{ matrix.engine }} --solver=${{ matrix.solver }} inputs/chiseltest/Quiz2.sat.btor > Quiz2.sat.wit
+          btorsim inputs/chiseltest/Quiz2.sat.btor Quiz2.sat.wit
+      - name: mc Quiz2 (with counter reset value)
+        run: |
+          cargo run --release -p mc -- --engine=${{ matrix.engine }} --solver=${{ matrix.solver }} inputs/chiseltest/Quiz2.unsat.btor
+      - name: mc Quiz4
+        run: |
+          cargo run --release -p mc -- --engine=${{ matrix.engine }} --solver=${{ matrix.solver }} inputs/chiseltest/Quiz4.sat.btor > Quiz4.sat.wit
+          btorsim inputs/chiseltest/Quiz4.sat.btor Quiz4.sat.wit
+      - name: mc Quiz4 (with counter reset value)
+        run: |
+          cargo run --release -p mc -- --engine=${{ matrix.engine }} --solver=${{ matrix.solver }} inputs/chiseltest/Quiz4.unsat.btor
+
+  bmc:
+    name: Test MC Tool with BMC
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     strategy:
@@ -73,7 +151,6 @@ jobs:
           - z3
         engine:
           - bmc
-          - pdr
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
         PATRONUS_TEST_SOLVER: ${{ matrix.solver }}
 
   mc:
-    name: Test MC Tool with BMC
+    name: Test MC Tool
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     strategy:
@@ -73,6 +73,7 @@ jobs:
           - z3
         engine:
           - bmc
+          - pdr
 
     steps:
       - uses: actions/checkout@v5

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -232,6 +232,9 @@ fn get_bit_level_cube(
                 let iw = av.index_width();
                 let dw = av.data_width();
 
+                // Make sure that no overflow occurs in iteration
+                assert!(iw < 64);
+
                 // Iterate over all array elements
                 for idx in 0u64..(1 << iw) {
                     // Read bit-vector value

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -614,6 +614,9 @@ impl BasePdr {
     /// "Fix" generalized cube by restoring enough removed literals until non-intersection
     /// with initial states
     ///
+    /// Follows implementation by Stanford Pono (<https://github.com/stanford-centaur/pono/blob/main/engines/ic3base.cpp#L929>)
+    /// and SMT-Switch (<https://github.com/stanford-centaur/smt-switch/blob/main/src/utils.cpp#L993>)
+    ///
     /// # Errors
     /// Returns [`Error::UnexpectedResponse`] if any SMT query returns `UNKNOWN` or original cube
     /// truly intersects the initial states
@@ -790,8 +793,7 @@ impl BasePdr {
             let gen_lits = genr
                 .literals
                 .iter()
-                .filter(|e| lit_map.contains_key(e))
-                .map(|e| lit_map[e])
+                .filter_map(|&lit| lit_map.get(&lit).copied())
                 .collect::<FxHashSet<_>>();
 
             // Literals not in UNSAT core

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -10,7 +10,7 @@ use crate::mc::{
 };
 use crate::smt::*;
 use crate::system::TransitionSystem;
-use baa::{BitVecOps, Value};
+use baa::{ArrayOps, BitVecOps, BitVecValue, Value};
 use rustc_hash::FxHashMap;
 use std::collections::BinaryHeap;
 use std::num::NonZeroUsize;
@@ -203,7 +203,7 @@ fn get_bit_level_cube(
     enc: &mut PdrEncodingWrapper<impl TransitionSystemEncoding>,
     step: Step,
 ) -> Result<Cube> {
-    let mut literals = Vec::new();
+    let mut literals = vec![];
 
     // Get state values
     let vals = extract_state_values(ctx, smt_ctx, sys, enc, step)?;
@@ -217,8 +217,7 @@ fn get_bit_level_cube(
                 // Get bitvector width
                 let width = bv.width();
 
-                // Iterate through all bits of the bitvector
-                // and assign bit-level equalities to concrete value
+                // Push all bit-vector bits
                 for idx in 0..width {
                     let bit = ctx.slice(sym, idx, idx);
                     let lit = if bv.is_bit_set(idx) {
@@ -229,7 +228,32 @@ fn get_bit_level_cube(
                     literals.push(lit);
                 }
             }
-            Value::Array(_av) => todo!("Add array support"),
+            Value::Array(av) => {
+                let iw = av.index_width();
+                let dw = av.data_width();
+
+                // Iterate over all array elements
+                for idx in 0u64..(1 << iw) {
+                    // Read bit-vector value
+                    let idx_val = BitVecValue::from_u64(idx, iw);
+                    let bv = av.select(&idx_val);
+
+                    // Read bit-vector symbol
+                    let idx_expr = ctx.bit_vec_val(idx, iw);
+                    let bv_expr = ctx.array_read(sym, idx_expr);
+
+                    // Push all bit-vector bits
+                    for idx in 0..dw {
+                        let bit = ctx.slice(bv_expr, idx, idx);
+                        let lit = if bv.is_bit_set(idx) {
+                            bit
+                        } else {
+                            ctx.not(bit)
+                        };
+                        literals.push(lit);
+                    }
+                }
+            }
         }
     }
 

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -930,7 +930,13 @@ impl BasePdr {
         // Try to solve all proof obligations
         while let Some(obj) = worklist.pop() {
             // If proof obligation intersects with initial states, blocking fails
-            if obj.frame == FrameId::Init {
+            let cube_expr = obj.cube.to_expr(ctx);
+            let cube_from = self.enc.expr_at_step(ctx, cube_expr, FROM_STEP);
+            if obj.frame == FrameId::Init
+                || self
+                    .intersects_init(ctx, smt_ctx, sys, [cube_from], false)?
+                    .0
+            {
                 return Ok(false);
             }
 

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -10,8 +10,8 @@ use crate::mc::{
 };
 use crate::smt::*;
 use crate::system::TransitionSystem;
-use baa::{ArrayOps, BitVecOps, BitVecValue, Value};
 use rustc_hash::{FxHashMap, FxHashSet};
+use baa::{ArrayOps, BitVecOps, BitVecValue, Value};
 use std::collections::BinaryHeap;
 use std::num::NonZeroUsize;
 use std::ops::{Index, IndexMut};

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -10,8 +10,8 @@ use crate::mc::{
 };
 use crate::smt::*;
 use crate::system::TransitionSystem;
-use rustc_hash::{FxHashMap, FxHashSet};
 use baa::{ArrayOps, BitVecOps, BitVecValue, Value};
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::BinaryHeap;
 use std::num::NonZeroUsize;
 use std::ops::{Index, IndexMut};

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -10,8 +10,8 @@ use crate::mc::{
 };
 use crate::smt::*;
 use crate::system::TransitionSystem;
-use rustc_hash::{FxHashMap, FxHashSet};
 use baa::{ArrayOps, BitVecOps, BitVecValue, Value};
+use rustc_hash::FxHashMap;
 use std::collections::BinaryHeap;
 use std::num::NonZeroUsize;
 use std::ops::{Index, IndexMut};
@@ -203,7 +203,7 @@ fn get_bit_level_cube(
     enc: &mut PdrEncodingWrapper<impl TransitionSystemEncoding>,
     step: Step,
 ) -> Result<Cube> {
-    let mut literals = Vec::new();
+    let mut literals = vec![];
 
     // Get state values
     let vals = extract_state_values(ctx, smt_ctx, sys, enc, step)?;

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -11,7 +11,7 @@ use crate::mc::{
 use crate::smt::*;
 use crate::system::TransitionSystem;
 use baa::{BitVecOps, Value};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::BinaryHeap;
 use std::num::NonZeroUsize;
 use std::ops::{Index, IndexMut};
@@ -611,6 +611,115 @@ impl BasePdr {
         }
     }
 
+    /// "Fix" generalized cube by restoring enough removed literals until non-intersection
+    /// with initial states
+    ///
+    /// # Errors
+    /// Returns [`Error::UnexpectedResponse`] if any SMT query returns `UNKNOWN` or original cube
+    /// truly intersects the initial states
+    fn fix_gen_cube(
+        &mut self,
+        ctx: &mut Context,
+        smt_ctx: &mut impl SolverContext,
+        sys: &TransitionSystem,
+        gen_cube: Cube,
+        rm_lits: impl IntoIterator<Item = ExprRef>,
+    ) -> Result<Cube> {
+        // If generalized cube already doesn't intersect with initial states, just return
+        let cube_expr = gen_cube.to_expr(ctx);
+        let cube_from = self.enc.expr_at_step(ctx, cube_expr, FROM_STEP);
+        if !self
+            .intersects_init(ctx, smt_ctx, sys, [cube_from], false)?
+            .0
+        {
+            return Ok(gen_cube);
+        }
+
+        // Create activation literals for original cube literals (predicates) that were
+        // dropped during generalization
+        let mut lit_map = FxHashMap::default();
+        for lit in rm_lits {
+            // Create activation literal implication
+            let act = self.create_act_lit(ctx, smt_ctx)?;
+            let expr_from = self.enc.expr_at_step(ctx, lit, FROM_STEP);
+            let imp = ctx.implies(act, expr_from);
+
+            // Assert in solver
+            smt_ctx.assert(ctx, imp)?;
+
+            // Add mapping
+            lit_map.insert(act, lit);
+        }
+
+        // Flag for first iteration
+        let mut first_iter = true;
+
+        // Original generalized cube at `FROM_STEP`
+        let cube_expr = gen_cube.to_expr(ctx);
+        let cube_from = self.enc.expr_at_step(ctx, cube_expr, FROM_STEP);
+
+        loop {
+            // Gather activation literals of original cube literals that could be dropped
+            let mut assumps = lit_map.keys().copied().collect::<Vec<_>>();
+
+            // Add original generalized cube to assumption
+            assumps.push(cube_from);
+
+            let check_res = self.intersects_init(ctx, smt_ctx, sys, assumps, true)?;
+
+            if check_res.0 && first_iter {
+                // Clean up activation literals
+                for &act in lit_map.keys() {
+                    let neg_act = ctx.not(act);
+                    smt_ctx.assert(ctx, neg_act)?;
+                }
+
+                // If first iteration, original cube must truly intersect with init frame
+                return Err(Error::UnexpectedResponse(
+                    "`fix_gen_cube` in `BasePdr`".into(),
+                    "original cube intersects with init".into(),
+                ));
+            }
+
+            // All removed literals should not be in UNSAT core
+            assert!(!check_res.0);
+
+            // Store previous number of literals
+            let prev_acts = lit_map.keys().copied().collect::<Vec<_>>();
+
+            // Collect all literals in the UNSAT core
+            let ex_cube = check_res.1.unwrap();
+            let gen_lits = ex_cube.literals.iter().collect::<FxHashSet<_>>();
+
+            // Remove all candidate literals not in UNSAT core
+            lit_map.retain(|e, _| gen_lits.contains(e));
+
+            // Permanently disable literals that were removed
+            for &act in &prev_acts {
+                if !lit_map.contains_key(&act) {
+                    let neg_act = ctx.not(act);
+                    smt_ctx.assert(ctx, neg_act)?;
+                }
+            }
+
+            if lit_map.len() == prev_acts.len() {
+                // If no literals are removed, then fixpoint reached
+                let mut fin_lits = gen_cube.literals;
+                fin_lits.extend(lit_map.values().copied());
+
+                // Clean up activation literals
+                for &act in lit_map.keys() {
+                    let neg_act = ctx.not(act);
+                    smt_ctx.assert(ctx, neg_act)?;
+                }
+
+                return Ok(Cube { literals: fin_lits });
+            }
+
+            first_iter = false;
+        }
+    }
+
     /// Run relative inductiveness query
     /// (i.e. `SAT?[R_{i - 1} /\ \neg c /\ T c']`)
     ///
@@ -677,30 +786,28 @@ impl BasePdr {
         let res = if smt_res.0 == CheckSatResponse::Unsat
             && let Some(genr) = smt_res.1
         {
-            // Get literals from UNSAT core that are in the candidate cube
+            // Literals in UNSAT core
             let gen_lits = genr
                 .literals
                 .iter()
-                .filter_map(|lit| lit_map.get(lit).copied())
+                .filter(|e| lit_map.contains_key(e))
+                .map(|e| lit_map[e])
+                .collect::<FxHashSet<_>>();
+
+            // Literals not in UNSAT core
+            let rm_lits = lit_map
+                .values()
+                .copied()
+                .filter(|e| !gen_lits.contains(e))
                 .collect::<Vec<_>>();
 
-            let gen_cube = Cube { literals: gen_lits };
+            // Make generalized cube not intersect initial states
+            let gen_cube = Cube {
+                literals: gen_lits.into_iter().collect(),
+            };
+            let fixed = self.fix_gen_cube(ctx, smt_ctx, sys, gen_cube, rm_lits)?;
 
-            // Step cube as expression at `FROM_STEP`
-            let gen_expr = gen_cube.to_expr(ctx);
-            let gen_from = self.enc.expr_at_step(ctx, gen_expr, FROM_STEP);
-
-            if self
-                .intersects_init(ctx, smt_ctx, sys, [gen_from], false)?
-                .0
-            {
-                // Generalized cube intersects with the initial states; adding it to the
-                // frame trace would be unsound
-                // Instead, return the original cube
-                Ok((CheckSatResponse::Unsat, Some(cube.cube.clone())))
-            } else {
-                Ok((CheckSatResponse::Unsat, Some(gen_cube)))
-            }
+            Ok((CheckSatResponse::Unsat, Some(fixed)))
         } else {
             Ok(smt_res)
         };

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -930,13 +930,7 @@ impl BasePdr {
         // Try to solve all proof obligations
         while let Some(obj) = worklist.pop() {
             // If proof obligation intersects with initial states, blocking fails
-            let cube_expr = obj.cube.to_expr(ctx);
-            let cube_from = self.enc.expr_at_step(ctx, cube_expr, FROM_STEP);
-            if obj.frame == FrameId::Init
-                || self
-                    .intersects_init(ctx, smt_ctx, sys, [cube_from], false)?
-                    .0
-            {
+            if obj.frame == FrameId::Init {
                 return Ok(false);
             }
 

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -11,7 +11,7 @@ use crate::mc::{
 use crate::smt::*;
 use crate::system::TransitionSystem;
 use baa::{ArrayOps, BitVecOps, BitVecValue, Value};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::BinaryHeap;
 use std::num::NonZeroUsize;
 use std::ops::{Index, IndexMut};
@@ -635,6 +635,115 @@ impl BasePdr {
         }
     }
 
+    /// "Fix" generalized cube by restoring enough removed literals until non-intersection
+    /// with initial states
+    ///
+    /// # Errors
+    /// Returns [`Error::UnexpectedResponse`] if any SMT query returns `UNKNOWN` or original cube
+    /// truly intersects the initial states
+    fn fix_gen_cube(
+        &mut self,
+        ctx: &mut Context,
+        smt_ctx: &mut impl SolverContext,
+        sys: &TransitionSystem,
+        gen_cube: Cube,
+        rm_lits: impl IntoIterator<Item = ExprRef>,
+    ) -> Result<Cube> {
+        // If generalized cube already doesn't intersect with initial states, just return
+        let cube_expr = gen_cube.to_expr(ctx);
+        let cube_from = self.enc.expr_at_step(ctx, cube_expr, FROM_STEP);
+        if !self
+            .intersects_init(ctx, smt_ctx, sys, [cube_from], false)?
+            .0
+        {
+            return Ok(gen_cube);
+        }
+
+        // Create activation literals for original cube literals (predicates) that were
+        // dropped during generalization
+        let mut lit_map = FxHashMap::default();
+        for lit in rm_lits {
+            // Create activation literal implication
+            let act = self.create_act_lit(ctx, smt_ctx)?;
+            let expr_from = self.enc.expr_at_step(ctx, lit, FROM_STEP);
+            let imp = ctx.implies(act, expr_from);
+
+            // Assert in solver
+            smt_ctx.assert(ctx, imp)?;
+
+            // Add mapping
+            lit_map.insert(act, lit);
+        }
+
+        // Flag for first iteration
+        let mut first_iter = true;
+
+        // Original generalized cube at `FROM_STEP`
+        let cube_expr = gen_cube.to_expr(ctx);
+        let cube_from = self.enc.expr_at_step(ctx, cube_expr, FROM_STEP);
+
+        loop {
+            // Gather activation literals of original cube literals that could be dropped
+            let mut assumps = lit_map.keys().copied().collect::<Vec<_>>();
+
+            // Add original generalized cube to assumption
+            assumps.push(cube_from);
+
+            let check_res = self.intersects_init(ctx, smt_ctx, sys, assumps, true)?;
+
+            if check_res.0 && first_iter {
+                // Clean up activation literals
+                for &act in lit_map.keys() {
+                    let neg_act = ctx.not(act);
+                    smt_ctx.assert(ctx, neg_act)?;
+                }
+
+                // If first iteration, original cube must truly intersect with init frame
+                return Err(Error::UnexpectedResponse(
+                    "`fix_gen_cube` in `BasePdr`".into(),
+                    "original cube intersects with init".into(),
+                ));
+            }
+
+            // All removed literals should not be in UNSAT core
+            assert!(!check_res.0);
+
+            // Store previous number of literals
+            let prev_acts = lit_map.keys().copied().collect::<Vec<_>>();
+
+            // Collect all literals in the UNSAT core
+            let ex_cube = check_res.1.unwrap();
+            let gen_lits = ex_cube.literals.iter().collect::<FxHashSet<_>>();
+
+            // Remove all candidate literals not in UNSAT core
+            lit_map.retain(|e, _| gen_lits.contains(e));
+
+            // Permanently disable literals that were removed
+            for &act in &prev_acts {
+                if !lit_map.contains_key(&act) {
+                    let neg_act = ctx.not(act);
+                    smt_ctx.assert(ctx, neg_act)?;
+                }
+            }
+
+            if lit_map.len() == prev_acts.len() {
+                // If no literals are removed, then fixpoint reached
+                let mut fin_lits = gen_cube.literals;
+                fin_lits.extend(lit_map.values().copied());
+
+                // Clean up activation literals
+                for &act in lit_map.keys() {
+                    let neg_act = ctx.not(act);
+                    smt_ctx.assert(ctx, neg_act)?;
+                }
+
+                return Ok(Cube { literals: fin_lits });
+            }
+
+            first_iter = false;
+        }
+    }
+
     /// Run relative inductiveness query
     /// (i.e. `SAT?[R_{i - 1} /\ \neg c /\ T c']`)
     ///
@@ -701,30 +810,28 @@ impl BasePdr {
         let res = if smt_res.0 == CheckSatResponse::Unsat
             && let Some(genr) = smt_res.1
         {
-            // Get literals from UNSAT core that are in the candidate cube
+            // Literals in UNSAT core
             let gen_lits = genr
                 .literals
                 .iter()
-                .filter_map(|lit| lit_map.get(lit).copied())
+                .filter(|e| lit_map.contains_key(e))
+                .map(|e| lit_map[e])
+                .collect::<FxHashSet<_>>();
+
+            // Literals not in UNSAT core
+            let rm_lits = lit_map
+                .values()
+                .copied()
+                .filter(|e| !gen_lits.contains(e))
                 .collect::<Vec<_>>();
 
-            let gen_cube = Cube { literals: gen_lits };
+            // Make generalized cube not intersect initial states
+            let gen_cube = Cube {
+                literals: gen_lits.into_iter().collect(),
+            };
+            let fixed = self.fix_gen_cube(ctx, smt_ctx, sys, gen_cube, rm_lits)?;
 
-            // Step cube as expression at `FROM_STEP`
-            let gen_expr = gen_cube.to_expr(ctx);
-            let gen_from = self.enc.expr_at_step(ctx, gen_expr, FROM_STEP);
-
-            if self
-                .intersects_init(ctx, smt_ctx, sys, [gen_from], false)?
-                .0
-            {
-                // Generalized cube intersects with the initial states; adding it to the
-                // frame trace would be unsound
-                // Instead, return the original cube
-                Ok((CheckSatResponse::Unsat, Some(cube.cube.clone())))
-            } else {
-                Ok((CheckSatResponse::Unsat, Some(gen_cube)))
-            }
+            Ok((CheckSatResponse::Unsat, Some(fixed)))
         } else {
             Ok(smt_res)
         };

--- a/patronus/src/sim/interface.rs
+++ b/patronus/src/sim/interface.rs
@@ -26,7 +26,7 @@ pub trait Simulator {
     /// Change the value or an expression in the simulator.
     fn set<'a>(&mut self, expr: ExprRef, value: impl Into<BitVecValueRef<'a>>);
 
-    /// Change the value fo an array expression in the simulator.
+    /// Change the value of an array expression in the simulator.
     fn set_array(&mut self, expr: ExprRef, value: ArrayValue);
 
     /// Inspect the value of any expression in the circuit

--- a/patronus/src/sim/interface.rs
+++ b/patronus/src/sim/interface.rs
@@ -26,6 +26,9 @@ pub trait Simulator {
     /// Change the value or an expression in the simulator.
     fn set<'a>(&mut self, expr: ExprRef, value: impl Into<BitVecValueRef<'a>>);
 
+    /// Change the value fo an array expression in the simulator.
+    fn set_array(&mut self, expr: ExprRef, value: ArrayValue);
+
     /// Inspect the value of any expression in the circuit
     fn get(&self, expr: ExprRef) -> Value;
 

--- a/patronus/src/sim/interpreter.rs
+++ b/patronus/src/sim/interpreter.rs
@@ -152,6 +152,10 @@ impl Simulator for Interpreter {
         self.data.update_bv(expr, value);
     }
 
+    fn set_array(&mut self, expr: ExprRef, value: ArrayValue) {
+        self.data.update_array(expr, value);
+    }
+
     fn get(&self, expr: ExprRef) -> Value {
         eval_expr(&self.ctx, &self.data, expr)
     }

--- a/patronus/tests/pdr.rs
+++ b/patronus/tests/pdr.rs
@@ -435,6 +435,7 @@ mod pdr {
         case_simple_fail_no_gen(&solver_from_env());
     }
 
+    #[ignore = "Need `fix_gen_cube` to pass"]
     #[test]
     fn test_quiz1_sat() {
         case_quiz1_sat(&solver_from_env());
@@ -445,6 +446,7 @@ mod pdr {
         case_quiz2_sat(&solver_from_env());
     }
 
+    #[ignore = "Need `fix_gen_cube` to pass"]
     #[test]
     fn test_quiz4_sat() {
         case_quiz4_sat(&solver_from_env());
@@ -491,11 +493,13 @@ mod pdr {
         case_quiz1_unsat(&solver_from_env());
     }
 
+    #[ignore = "Need `fix_gen_cube` to pass"]
     #[test]
     fn test_quiz2_unsat() {
         case_quiz2_unsat(&solver_from_env());
     }
 
+    #[ignore = "Need `fix_gen_cube` to pass"]
     #[test]
     fn test_quiz4_unsat() {
         case_quiz4_unsat(&solver_from_env());

--- a/patronus/tests/pdr.rs
+++ b/patronus/tests/pdr.rs
@@ -438,7 +438,6 @@ mod pdr {
         case_simple_fail_no_gen(&solver_from_env());
     }
 
-    #[ignore = "Need `fix_gen_cube` to pass"]
     #[test]
     fn test_quiz1_sat() {
         case_quiz1_sat(&solver_from_env());
@@ -449,7 +448,6 @@ mod pdr {
         case_quiz2_sat(&solver_from_env());
     }
 
-    #[ignore = "Need `fix_gen_cube` to pass"]
     #[test]
     fn test_quiz4_sat() {
         case_quiz4_sat(&solver_from_env());
@@ -496,13 +494,11 @@ mod pdr {
         case_quiz1_unsat(&solver_from_env());
     }
 
-    #[ignore = "Need `fix_gen_cube` to pass"]
     #[test]
     fn test_quiz2_unsat() {
         case_quiz2_unsat(&solver_from_env());
     }
 
-    #[ignore = "Need `fix_gen_cube` to pass"]
     #[test]
     fn test_quiz4_unsat() {
         case_quiz4_unsat(&solver_from_env());

--- a/patronus/tests/pdr.rs
+++ b/patronus/tests/pdr.rs
@@ -438,6 +438,7 @@ mod pdr {
         case_simple_fail_no_gen(&solver_from_env());
     }
 
+    #[ignore = "Need `fix_gen_cube` to pass"]
     #[test]
     fn test_quiz1_sat() {
         case_quiz1_sat(&solver_from_env());
@@ -448,6 +449,7 @@ mod pdr {
         case_quiz2_sat(&solver_from_env());
     }
 
+    #[ignore = "Need `fix_gen_cube` to pass"]
     #[test]
     fn test_quiz4_sat() {
         case_quiz4_sat(&solver_from_env());
@@ -494,11 +496,13 @@ mod pdr {
         case_quiz1_unsat(&solver_from_env());
     }
 
+    #[ignore = "Need `fix_gen_cube` to pass"]
     #[test]
     fn test_quiz2_unsat() {
         case_quiz2_unsat(&solver_from_env());
     }
 
+    #[ignore = "Need `fix_gen_cube` to pass"]
     #[test]
     fn test_quiz4_unsat() {
         case_quiz4_unsat(&solver_from_env());

--- a/patronus/tests/pdr.rs
+++ b/patronus/tests/pdr.rs
@@ -299,9 +299,12 @@ fn case_quiz4_sat(solver: &SmtLibSolver) {
 }
 
 fn case_const_array(solver: &SmtLibSolver) {
-    let Some((ctx, sys, res)) =
-        run_pdr_file(solver, "../inputs/chiseltest/const_array_example.btor", None, false)
-    else {
+    let Some((ctx, sys, res)) = run_pdr_file(
+        solver,
+        "../inputs/chiseltest/const_array_example.btor",
+        None,
+        false,
+    ) else {
         return;
     };
 

--- a/patronus/tests/pdr.rs
+++ b/patronus/tests/pdr.rs
@@ -421,7 +421,6 @@ mod pdr {
         case_simple_fail_no_gen(&solver_from_env());
     }
 
-    #[ignore = "Need `fix_gen_cube` to pass"]
     #[test]
     fn test_quiz1_sat() {
         case_quiz1_sat(&solver_from_env());
@@ -432,7 +431,6 @@ mod pdr {
         case_quiz2_sat(&solver_from_env());
     }
 
-    #[ignore = "Need `fix_gen_cube` to pass"]
     #[test]
     fn test_quiz4_sat() {
         case_quiz4_sat(&solver_from_env());
@@ -474,13 +472,11 @@ mod pdr {
         case_quiz1_unsat(&solver_from_env());
     }
 
-    #[ignore = "Need `fix_gen_cube` to pass"]
     #[test]
     fn test_quiz2_unsat() {
         case_quiz2_unsat(&solver_from_env());
     }
 
-    #[ignore = "Need `fix_gen_cube` to pass"]
     #[test]
     fn test_quiz4_unsat() {
         case_quiz4_unsat(&solver_from_env());

--- a/patronus/tests/pdr.rs
+++ b/patronus/tests/pdr.rs
@@ -130,7 +130,7 @@ fn validate_witness(ctx: &Context, sys: &TransitionSystem, wit: &Witness) {
     for (state, init_val) in sys.states.iter().zip(wit.init.iter()) {
         match init_val {
             InitValue::BitVec(bv) => sim.set(state.symbol, bv),
-            InitValue::Array(_av, _) => panic!("No array support"),
+            InitValue::Array(av, _) => sim.set_array(state.symbol, av.clone()),
             InitValue::None => {}
         }
     }
@@ -141,7 +141,7 @@ fn validate_witness(ctx: &Context, sys: &TransitionSystem, wit: &Witness) {
         for (inp_sym, inp_val) in sys.inputs.iter().zip(step_inputs.iter()) {
             match inp_val {
                 Some(Value::BitVec(bv)) => sim.set(*inp_sym, bv),
-                Some(Value::Array(_av)) => panic!("No array support"),
+                Some(Value::Array(av)) => sim.set_array(*inp_sym, av.clone()),
                 None => {}
             }
         }
@@ -298,6 +298,20 @@ fn case_quiz4_sat(solver: &SmtLibSolver) {
     }
 }
 
+fn case_const_array(solver: &SmtLibSolver) {
+    let Some((ctx, sys, res)) =
+        run_pdr_file(solver, "../inputs/chiseltest/const_array_example.btor", None, false)
+    else {
+        return;
+    };
+
+    if let ModelCheckResult::Fail(wit) = res {
+        validate_witness(&ctx, &sys, &wit);
+    } else {
+        panic!("const_array failed");
+    }
+}
+
 fn case_delay(solver: &SmtLibSolver) {
     let Some((_, _, res)) = run_pdr_file(solver, "../inputs/verilog_tests/Delay.btor", None, false)
     else {
@@ -436,6 +450,11 @@ mod pdr {
     #[test]
     fn test_quiz4_sat() {
         case_quiz4_sat(&solver_from_env());
+    }
+
+    #[test]
+    fn test_const_array() {
+        case_const_array(&solver_from_env());
     }
 
     #[test]


### PR DESCRIPTION
# Changes 

- Added rudimentary array support in PDR by creating a `Cube` with all array bits in `get_bit_level_cube`
- Extended `Simulator` trait with `set_array` method so `validate_witness` test code can properly set array values in the simulator
- Extended CI/CD with PDR engine MC tool tests, making sure to exclude YICES2 (which currently does not have UNSAT core support and therefore pass the BMC CI/CD tests; will be fixed once all query assumptions are changed to Boolean literals)

# Testing

All regression tests pass.