### PR TITLE
Enhance BTOR parser with negated node IDs and error handling

### DIFF
--- a/patronus/src/btor2/parse.rs
+++ b/patronus/src/btor2/parse.rs
@@ -155,7 +155,11 @@ impl<'a> Parser<'a> {
         // the first token should be an _non-negative integer_ ID
         let (line_id, not) = self.parse_line_id(line, tokens[0])?;
         if not {
-            return self.add_error(line, tokens[0], "Line numbers must be non-negative integers.".to_owned());
+            return self.add_error(
+                line,
+                tokens[0],
+                "Line numbers must be non-negative integers.".to_owned(),
+            );
         }
 
         // make sure that there is a second token following the id
@@ -569,15 +573,15 @@ impl<'a> Parser<'a> {
                 Err(())
             }
             Some(id) => {
-               if id > i64::from(LineId::MAX) || id < -i64::from(LineId::MAX) {
-                   // If line ID is overflows in [`LineId`], return parse error
-                   let _ = self.add_error(
-                       line,
-                       token,
-                       "Expected non-negative integer ID or negated ID".to_owned(),
-                   );
-                   return Err(());
-               }
+                if id > i64::from(LineId::MAX) || id < -i64::from(LineId::MAX) {
+                    // If line ID is overflows in [`LineId`], return parse error
+                    let _ = self.add_error(
+                        line,
+                        token,
+                        "Expected non-negative integer ID or negated ID".to_owned(),
+                    );
+                    return Err(());
+                }
 
                 Ok((id.abs() as LineId, id.is_negative()))
             }
@@ -691,7 +695,7 @@ impl<'a> Parser<'a> {
         if let Some(signal) = self.signal_map.get(&signal_id)
             && !(not && signal.get_type(self.ctx) != Type::BV(1))
         {
-            Ok(if not { self.ctx.not(*signal) } else { *signal } )
+            Ok(if not { self.ctx.not(*signal) } else { *signal })
         } else {
             let _ = self.add_error(
                 line,

--- a/patronus/src/btor2/parse.rs
+++ b/patronus/src/btor2/parse.rs
@@ -2,7 +2,6 @@
 // released under BSD 3-Clause License
 // author: Kevin Laeufer <laeufer@berkeley.edu>
 
-use crate::expr::Type::BV;
 use crate::expr::*;
 use crate::system::transform::do_transform;
 use crate::system::*;
@@ -560,17 +559,29 @@ impl<'a> Parser<'a> {
     /// # Returns
     /// (Parse line id, whether line ID was negated)
     fn parse_line_id(&mut self, line: &str, token: &str) -> ParseLineResult<(LineId, bool)> {
-        token.parse::<i64>().map_or_else(
-            |_| {
+        match token.parse::<i64>().ok() {
+            None => {
                 let _ = self.add_error(
                     line,
                     token,
                     "Expected non-negative integer ID or negated ID".to_owned(),
                 );
                 Err(())
-            },
-            |id| Ok((id.abs() as LineId, id < 0)),
-        )
+            }
+            Some(id) => {
+               if id > i64::from(LineId::MAX) || id < -i64::from(LineId::MAX) {
+                   // If line ID is overflows in [`LineId`], return parse error
+                   let _ = self.add_error(
+                       line,
+                       token,
+                       "Expected non-negative integer ID or negated ID".to_owned(),
+                   );
+                   return Err(());
+               }
+
+                Ok((id.abs() as LineId, id.is_negative()))
+            }
+        }
     }
 
     fn parse_ones(&mut self, line: &str, tokens: &[&str]) -> ParseLineResult<(ExprRef, usize)> {
@@ -678,7 +689,7 @@ impl<'a> Parser<'a> {
         // Reject non-existent signals or negated signals who reference
         // non-Boolean (more than one bit) signals
         if let Some(signal) = self.signal_map.get(&signal_id)
-            && !(not && signal.get_type(self.ctx) != BV(1))
+            && !(not && signal.get_type(self.ctx) != Type::BV(1))
         {
             Ok(if not { self.ctx.not(*signal) } else { *signal } )
         } else {

--- a/patronus/src/btor2/parse.rs
+++ b/patronus/src/btor2/parse.rs
@@ -692,17 +692,7 @@ impl<'a> Parser<'a> {
 
         // Check if signal exists
         if let Some(signal) = self.signal_map.get(&signal_id) {
-            // Make sure that only length-1 bitvectors (Boolean signals) are negated
-            if not && signal.get_type(self.ctx) != Type::BV(1) {
-                let _ = self.add_error(
-                    line,
-                    token,
-                    "Only length-1 bitvectors can be negated".to_owned(),
-                );
-                Err(())
-            } else {
-                Ok(if not { self.ctx.not(*signal) } else { *signal })
-            }
+            Ok(if not { self.ctx.not(*signal) } else { *signal })
         } else {
             let _ = self.add_error(
                 line,

--- a/patronus/src/btor2/parse.rs
+++ b/patronus/src/btor2/parse.rs
@@ -2,6 +2,7 @@
 // released under BSD 3-Clause License
 // author: Kevin Laeufer <laeufer@berkeley.edu>
 
+use crate::expr::Type::BV;
 use crate::expr::*;
 use crate::system::transform::do_transform;
 use crate::system::*;
@@ -152,8 +153,11 @@ impl<'a> Parser<'a> {
             return Ok(());
         }
 
-        // the first token should be an ID
-        let line_id = self.parse_line_id(line, tokens[0])?;
+        // the first token should be an _non-negative integer_ ID
+        let (line_id, not) = self.parse_line_id(line, tokens[0])?;
+        if not {
+            return self.add_error(line, tokens[0], "Line numbers must be non-negative integers.".to_owned());
+        }
 
         // make sure that there is a second token following the id
         let op: &str = match tokens.get(1) {
@@ -553,18 +557,20 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
-    fn parse_line_id(&mut self, line: &str, token: &str) -> ParseLineResult<LineId> {
-        match token.parse::<LineId>().ok() {
-            None => {
+    /// # Returns
+    /// (Parse line id, whether line ID was negated)
+    fn parse_line_id(&mut self, line: &str, token: &str) -> ParseLineResult<(LineId, bool)> {
+        token.parse::<i64>().map_or_else(
+            |_| {
                 let _ = self.add_error(
                     line,
                     token,
-                    "Expected valid non-negative integer ID.".to_owned(),
+                    "Expected non-negative integer ID or negated ID".to_owned(),
                 );
                 Err(())
-            }
-            Some(id) => Ok(id),
-        }
+            },
+            |id| Ok((id.abs() as LineId, id < 0)),
+        )
     }
 
     fn parse_ones(&mut self, line: &str, tokens: &[&str]) -> ParseLineResult<(ExprRef, usize)> {
@@ -635,49 +641,54 @@ impl<'a> Parser<'a> {
     }
 
     fn get_tpe_from_id(&mut self, line: &str, token: &str) -> ParseLineResult<Type> {
-        let tpe_id = self.parse_line_id(line, token)?;
-        match self.type_map.get(&tpe_id) {
-            None => {
-                let _ = self.add_error(
-                    line,
-                    token,
-                    format!("ID `{tpe_id}` does not point to a valid type!"),
-                );
-                Err(())
-            }
-            Some(tpe) => Ok(*tpe),
+        let (tpe_id, not) = self.parse_line_id(line, token)?;
+
+        // Make sure that types are never negated
+        if !not && let Some(tpe) = self.type_map.get(&tpe_id) {
+            Ok(*tpe)
+        } else {
+            let _ = self.add_error(
+                line,
+                token,
+                format!("ID `{tpe_id}` does not point to a valid type!"),
+            );
+            Err(())
         }
     }
 
     fn get_state_from_id(&mut self, line: &str, token: &str) -> ParseLineResult<StateRef> {
-        let state_id = self.parse_line_id(line, token)?;
-        match self.state_map.get(&state_id) {
-            None => {
-                let _ = self.add_error(
-                    line,
-                    token,
-                    format!("ID `{state_id}` does not point to a valid state!"),
-                );
-                Err(())
-            }
-            Some(state) => Ok(*state),
+        let (state_id, not) = self.parse_line_id(line, token)?;
+
+        // Make sure that states definitions are never negated
+        if !not && let Some(state) = self.state_map.get(&state_id) {
+            Ok(*state)
+        } else {
+            let _ = self.add_error(
+                line,
+                token,
+                format!("ID `{state_id}` does not point to a valid state!"),
+            );
+            Err(())
         }
     }
 
     fn get_expr_from_line_id(&mut self, line: &str, token: &str) -> ParseLineResult<ExprRef> {
-        let signal_id = self.parse_line_id(line, token)?;
-        let expr_ref = match self.signal_map.get(&signal_id) {
-            None => {
-                let _ = self.add_error(
-                    line,
-                    token,
-                    format!("ID `{signal_id}` does not point to a valid signal!"),
-                );
-                Err(())
-            }
-            Some(signal) => Ok(*signal),
-        }?;
-        Ok(expr_ref)
+        let (signal_id, not) = self.parse_line_id(line, token)?;
+
+        // Reject non-existent signals or negated signals who reference
+        // non-Boolean (more than one bit) signals
+        if let Some(signal) = self.signal_map.get(&signal_id)
+            && !(not && signal.get_type(self.ctx) != BV(1))
+        {
+            Ok(if not { self.ctx.not(*signal) } else { *signal } )
+        } else {
+            let _ = self.add_error(
+                line,
+                token,
+                format!("ID `{signal_id}` does not point to a valid signal!"),
+            );
+            Err(())
+        }
     }
 
     fn parse_sort(&mut self, line: &str, tokens: &[&str], line_id: LineId) -> ParseLineResult {

--- a/patronus/src/btor2/parse.rs
+++ b/patronus/src/btor2/parse.rs
@@ -690,12 +690,19 @@ impl<'a> Parser<'a> {
     fn get_expr_from_line_id(&mut self, line: &str, token: &str) -> ParseLineResult<ExprRef> {
         let (signal_id, not) = self.parse_line_id(line, token)?;
 
-        // Reject non-existent signals or negated signals who reference
-        // non-Boolean (more than one bit) signals
-        if let Some(signal) = self.signal_map.get(&signal_id)
-            && !(not && signal.get_type(self.ctx) != Type::BV(1))
-        {
-            Ok(if not { self.ctx.not(*signal) } else { *signal })
+        // Check if signal exists
+        if let Some(signal) = self.signal_map.get(&signal_id) {
+            // Make sure that only length-1 bitvectors (Boolean signals) are negated
+            if not && signal.get_type(self.ctx) != Type::BV(1) {
+                let _ = self.add_error(
+                    line,
+                    token,
+                    "Only length-1 bitvectors can be negated".to_owned(),
+                );
+                Err(())
+            } else {
+                Ok(if not { self.ctx.not(*signal) } else { *signal })
+            }
         } else {
             let _ = self.add_error(
                 line,

--- a/patronus/tests/btor2_test.rs
+++ b/patronus/tests/btor2_test.rs
@@ -203,8 +203,7 @@ const NEG_LINES: &str = r"
 #[test]
 fn parse_neg_nodes() {
     let mut ctx = Context::default();
-    let sys =
-        btor2::parse_str(&mut ctx, NEG_LINES, Some("neg_lines")).unwrap();
+    let sys = btor2::parse_str(&mut ctx, NEG_LINES, Some("neg_lines")).unwrap();
 
     insta::assert_snapshot!(sys.serialize_to_str(&ctx));
 }
@@ -224,8 +223,7 @@ const LARGE_LINES: &str = r"
 #[test]
 fn parse_large_line() {
     let mut ctx = Context::default();
-    let sys =
-        btor2::parse_str(&mut ctx, LARGE_LINES, Some("large_lines")).unwrap();
+    let sys = btor2::parse_str(&mut ctx, LARGE_LINES, Some("large_lines")).unwrap();
 
     insta::assert_snapshot!(sys.serialize_to_str(&ctx));
 }
@@ -252,8 +250,7 @@ const COMPLEX_NEG_LINES: &str = r"
 #[test]
 fn complex_parse_neg_nodes() {
     let mut ctx = Context::default();
-    let sys =
-        btor2::parse_str(&mut ctx, COMPLEX_NEG_LINES, Some("complex_neg_lines")).unwrap();
+    let sys = btor2::parse_str(&mut ctx, COMPLEX_NEG_LINES, Some("complex_neg_lines")).unwrap();
 
     insta::assert_snapshot!(sys.serialize_to_str(&ctx));
 }
@@ -320,7 +317,13 @@ const OVERFLOW_LINE_NUM_NEG: &str = r"
 
 #[test]
 fn parse_neg_nodes_errors() {
-    for test in [NON_BOOL_NEG_LINE, NEG_LINE_TYPE, NEG_LINE_NUM, OVERFLOW_LINE_NUM, OVERFLOW_LINE_NUM_NEG] {
+    for test in [
+        NON_BOOL_NEG_LINE,
+        NEG_LINE_TYPE,
+        NEG_LINE_NUM,
+        OVERFLOW_LINE_NUM,
+        OVERFLOW_LINE_NUM_NEG,
+    ] {
         let mut ctx = Context::default();
         assert!(btor2::parse_str(&mut ctx, test, Some("error_test")).is_none());
     }

--- a/patronus/tests/btor2_test.rs
+++ b/patronus/tests/btor2_test.rs
@@ -256,7 +256,7 @@ fn complex_parse_neg_nodes() {
 }
 
 /// Circuit with non-Boolean (i.e. not length-1) bitvectors
-const NON_BOOL_NEG_LINE: &str = r"
+const NON_BOOL_NEG_LINES: &str = r"
        1 sort bitvec 3
        2 zero 1
        3 state 1 first
@@ -266,6 +266,14 @@ const NON_BOOL_NEG_LINE: &str = r"
        7 and 1 -3 4
        8 output 7 out
        ";
+
+#[test]
+fn non_bool_parse_neg_nodes() {
+    let mut ctx = Context::default();
+    let sys = btor2::parse_str(&mut ctx, NON_BOOL_NEG_LINES, Some("non_bool_neg_lines")).unwrap();
+
+    insta::assert_snapshot!(sys.serialize_to_str(&ctx));
+}
 
 /// Circuit with negated type references
 const NEG_LINE_TYPE: &str = r"
@@ -318,7 +326,6 @@ const OVERFLOW_LINE_NUM_NEG: &str = r"
 #[test]
 fn parse_neg_nodes_errors() {
     for test in [
-        NON_BOOL_NEG_LINE,
         NEG_LINE_TYPE,
         NEG_LINE_NUM,
         OVERFLOW_LINE_NUM,

--- a/patronus/tests/btor2_test.rs
+++ b/patronus/tests/btor2_test.rs
@@ -199,11 +199,33 @@ const NEG_LINES: &str = r"
         7 and 1 -3 4
         8 output 7 out
         ";
+
 #[test]
 fn parse_neg_nodes() {
     let mut ctx = Context::default();
     let sys =
         btor2::parse_str(&mut ctx, NEG_LINES, Some("neg_lines")).unwrap();
+
+    insta::assert_snapshot!(sys.serialize_to_str(&ctx));
+}
+
+/// Small circuit with large line numbers
+const LARGE_LINES: &str = r"
+        1 sort bitvec 1
+        2 zero 1
+        3 state 1 first
+        4 state 1 sec
+        5 init 1 3 2
+        6 init 1 4 2
+        4294967295 and 1 -3 4
+        8 output 4294967295 out
+        ";
+
+#[test]
+fn parse_large_line() {
+    let mut ctx = Context::default();
+    let sys =
+        btor2::parse_str(&mut ctx, LARGE_LINES, Some("large_lines")).unwrap();
 
     insta::assert_snapshot!(sys.serialize_to_str(&ctx));
 }
@@ -272,11 +294,33 @@ const NEG_LINE_NUM: &str = r"
        8 output 7 out
        ";
 
+/// Circuit with overflowed line numbers
+const OVERFLOW_LINE_NUM: &str = r"
+       1 sort bitvec 1
+       2 zero 1
+       -3 state 1 first
+       4 state 1 sec
+       5 init 1 3 2
+       6 init 1 4 2
+       4294967296 and 1 -3 4
+       8 output 4294967296 out
+       ";
+
+/// Circuit with overflowed line numbers (negative wrap-around)
+const OVERFLOW_LINE_NUM_NEG: &str = r"
+       1 sort bitvec 1
+       2 zero 1
+       -3 state 1 first
+       4 state 1 sec
+       5 init 1 3 2
+       6 init 1 4 2
+       -9223372036854775808 and 1 -3 4
+       8 output -9223372036854775808 out
+       ";
+
 #[test]
 fn parse_neg_nodes_errors() {
-    for test in [NON_BOOL_NEG_LINE, NEG_LINE_TYPE, NEG_LINE_NUM] {
-        eprintln!("{test}");
-
+    for test in [NON_BOOL_NEG_LINE, NEG_LINE_TYPE, NEG_LINE_NUM, OVERFLOW_LINE_NUM, OVERFLOW_LINE_NUM_NEG] {
         let mut ctx = Context::default();
         assert!(btor2::parse_str(&mut ctx, test, Some("error_test")).is_none());
     }

--- a/patronus/tests/btor2_test.rs
+++ b/patronus/tests/btor2_test.rs
@@ -188,6 +188,100 @@ fn parse_llsdspi_bug_c1_instrumented() {
     println!("{}", sys.serialize_to_str(&ctx));
 }
 
+// Small circuit with negated line IDs
+const NEG_LINES: &str = r"
+        1 sort bitvec 1
+        2 zero 1
+        3 state 1 first
+        4 state 1 sec
+        5 init 1 3 2
+        6 init 1 4 2
+        7 and 1 -3 4
+        8 output 7 out
+        ";
+#[test]
+fn parse_neg_nodes() {
+    let mut ctx = Context::default();
+    let sys =
+        btor2::parse_str(&mut ctx, NEG_LINES, Some("neg_lines")).unwrap();
+
+    insta::assert_snapshot!(sys.serialize_to_str(&ctx));
+}
+
+/// More complex circuit with negated line IDs
+const COMPLEX_NEG_LINES: &str = r"
+        1 sort bitvec 1
+        2 zero 1
+        3 ones 1
+        4 state 1 first
+        5 state 1 sec
+        6 state 1 third
+        7 init 1 4 3
+        8 init 1 5 2
+        9 init 1 6 3
+        10 and 1 4 -6
+        11 or 1 -10 6
+        12 xor 1 4 -11
+        13 input 1 act
+        14 implies 1 13 12
+        15 output 14 out
+        ";
+
+#[test]
+fn complex_parse_neg_nodes() {
+    let mut ctx = Context::default();
+    let sys =
+        btor2::parse_str(&mut ctx, COMPLEX_NEG_LINES, Some("complex_neg_lines")).unwrap();
+
+    insta::assert_snapshot!(sys.serialize_to_str(&ctx));
+}
+
+/// Circuit with non-Boolean (i.e. not length-1) bitvectors
+const NON_BOOL_NEG_LINE: &str = r"
+       1 sort bitvec 3
+       2 zero 1
+       3 state 1 first
+       4 state 1 sec
+       5 init 1 3 2
+       6 init 1 4 2
+       7 and 1 -3 4
+       8 output 7 out
+       ";
+
+/// Circuit with negated type references
+const NEG_LINE_TYPE: &str = r"
+       1 sort bitvec 1
+       2 zero 1
+       3 state 1 first
+       4 state -1 sec
+       5 init 1 3 2
+       6 init 1 4 2
+       7 and 1 -3 4
+       8 output 7 out
+       ";
+
+/// Circuit with negated line numbers
+const NEG_LINE_NUM: &str = r"
+       1 sort bitvec 1
+       2 zero 1
+       -3 state 1 first
+       4 state 1 sec
+       5 init 1 3 2
+       6 init 1 4 2
+       7 and 1 -3 4
+       8 output 7 out
+       ";
+
+#[test]
+fn parse_neg_nodes_errors() {
+    for test in [NON_BOOL_NEG_LINE, NEG_LINE_TYPE, NEG_LINE_NUM] {
+        eprintln!("{test}");
+
+        let mut ctx = Context::default();
+        assert!(btor2::parse_str(&mut ctx, test, Some("error_test")).is_none());
+    }
+}
+
 /// Serialize → parse → serialize, then require the two serializations match.
 /// This is the strongest check we can make without comparing IR directly: any
 /// information the serializer drops or mangles will show up as a text diff on

--- a/patronus/tests/snapshots/btor2_test__complex_parse_neg_nodes.snap
+++ b/patronus/tests/snapshots/btor2_test__complex_parse_neg_nodes.snap
@@ -1,0 +1,13 @@
+---
+source: patronus/tests/btor2_test.rs
+expression: sys.serialize_to_str(&ctx)
+---
+complex_neg_lines
+input act : bv<1>
+output out : bv<1> = implies(act, xor(first, not(or(not(and(first, not(third))), third))))
+state first : bv<1>
+  [init] 1'b1
+state sec : bv<1>
+  [init] 1'b0
+state third : bv<1>
+  [init] 1'b1

--- a/patronus/tests/snapshots/btor2_test__non_bool_parse_neg_nodes.snap
+++ b/patronus/tests/snapshots/btor2_test__non_bool_parse_neg_nodes.snap
@@ -1,0 +1,10 @@
+---
+source: patronus/tests/btor2_test.rs
+expression: sys.serialize_to_str(&ctx)
+---
+non_bool_neg_lines
+output out : bv<3> = and(not(first), sec)
+state first : bv<3>
+  [init] 3'b000
+state sec : bv<3>
+  [init] 3'b000

--- a/patronus/tests/snapshots/btor2_test__parse_large_line.snap
+++ b/patronus/tests/snapshots/btor2_test__parse_large_line.snap
@@ -1,0 +1,10 @@
+---
+source: patronus/tests/btor2_test.rs
+expression: sys.serialize_to_str(&ctx)
+---
+large_lines
+output out : bv<1> = and(not(first), sec)
+state first : bv<1>
+  [init] 1'b0
+state sec : bv<1>
+  [init] 1'b0

--- a/patronus/tests/snapshots/btor2_test__parse_neg_nodes.snap
+++ b/patronus/tests/snapshots/btor2_test__parse_neg_nodes.snap
@@ -1,0 +1,10 @@
+---
+source: patronus/tests/btor2_test.rs
+expression: sys.serialize_to_str(&ctx)
+---
+neg_lines
+output out : bv<1> = and(not(first), sec)
+state first : bv<1>
+  [init] 1'b0
+state sec : bv<1>
+  [init] 1'b0


### PR DESCRIPTION
# Changes

- Added support for negated node IDs in BTOR parser for bitvector expressions
- Added error handling for incorrect negated node ID usage (negative line numbers, negative node IDs for sorts)
- Added new tests to ensure functionality and proper error handling for new parser features