### PR TITLE
Add proxy variables for compound expression query assumptions

### DIFF
--- a/patronus/src/mc/bmc.rs
+++ b/patronus/src/mc/bmc.rs
@@ -38,6 +38,8 @@ pub fn bmc(
     let constraints = sys.constraints.clone();
     let bad_states = sys.bad_states.clone();
 
+    let mut next_proxy_id = 0u64;
+
     if k_max > 0 && sys.states.is_empty() {
         println!(
             "[warn]: k_max={k_max} is unnecessarily large. System {} has no states.",
@@ -65,6 +67,7 @@ pub fn bmc(
 
         if check_bad_states_individually {
             for expr_ref in bad_states.iter() {
+                // don't need to proxy because bad state signals are effectively Boolean literals
                 let expr = enc.get_signal_at(ctx, *expr_ref, k);
                 let res = check_assuming(ctx, smt_ctx, [expr])?;
 
@@ -81,8 +84,16 @@ pub fn bmc(
                 .iter()
                 .map(|expr_ref| enc.get_signal_at(ctx, *expr_ref, k))
                 .collect::<Vec<_>>();
+
+            let bad_proxy = ctx.bv_symbol(format!("__bmc_act_{next_proxy_id}").as_str(), 1);
+            smt_ctx.declare_const(ctx, bad_proxy)?;
+
             let any_bad = all_bads.into_iter().reduce(|a, b| ctx.or(a, b)).unwrap();
-            let res = check_assuming(ctx, smt_ctx, [any_bad])?;
+            let imp = ctx.implies(bad_proxy, any_bad);
+            smt_ctx.assert(ctx, imp)?;
+            next_proxy_id += 1;
+
+            let res = check_assuming(ctx, smt_ctx, [bad_proxy])?;
 
             // count expression uses
             let use_counts = count_system_expr_uses(ctx, sys);
@@ -91,6 +102,10 @@ pub fn bmc(
                 return Ok(ModelCheckResult::Fail(wit));
             }
             check_assuming_end(smt_ctx)?;
+
+            // Clean up
+            let neg_proxy = ctx.not(bad_proxy);
+            smt_ctx.assert(ctx, neg_proxy)?;
         }
 
         // advance

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -526,7 +526,7 @@ impl BasePdr {
     /// # Returns
     /// SMT expression asserting over-approximation of states reachable in `frame` steps
     /// (i.e. state space of `frame`-th frame), stepped at pre-transition step
-    fn frame_assumptions(&self, ctx: &mut Context, frame_id: FrameId) -> ExprRef {
+    fn frame_assumptions(&mut self, ctx: &mut Context, smt_ctx: &mut impl SolverContext, frame_id: FrameId) -> Result<ExprRef> {
         assert!(
             frame_id == FrameId::Init
                 || frame_id <= self.frontier()
@@ -535,15 +535,20 @@ impl BasePdr {
 
         // Special case: for init frame, just return initial activation literal
         if frame_id == FrameId::Init {
-            return self.iter().fold(self.init_frame, |acc, id| {
+            let init_proxy = self.create_act_lit(ctx, smt_ctx)?;
+            let init_assump = self.iter().fold(self.init_frame, |acc, id| {
                 let neg_act = ctx.not(self[id].act);
                 ctx.and(acc, neg_act)
             });
+            let imp = ctx.implies(init_proxy, init_assump);
+            smt_ctx.assert(ctx, imp)?;
+
+            return Ok(init_proxy);
         }
 
         // Conjunct all blocked cubes in this frame and higher (since all blocked
         // cubes in higher delta frames are also blocked in this frame)
-        self.iter().fold(ctx.not(self.init_frame), |acc, id| {
+        let frame_assump = self.iter().fold(ctx.not(self.init_frame), |acc, id| {
             if id >= frame_id {
                 // Include activation literals of target frame and all higher frames,
                 // which include cubes blocked in the `frame_id`-th frame
@@ -555,7 +560,15 @@ impl BasePdr {
                 let neg_act = ctx.not(self[id].act);
                 ctx.and(acc, neg_act)
             }
-        })
+        });
+
+        // Introduce proxy variable for frame assumptions (i.e. x = frame_assump)
+        // to avoid compound SMT expression
+        let proxy = self.create_act_lit(ctx, smt_ctx)?;
+        let imp = ctx.implies(proxy, frame_assump);
+        smt_ctx.assert(ctx, imp)?;
+
+        Ok(proxy)
     }
 
     /// Check if assumptions intersect with the initial states
@@ -575,7 +588,7 @@ impl BasePdr {
         get_unsat_core: bool,
     ) -> Result<(bool, Option<Cube>)> {
         // Initial frame
-        let init = self.frame_assumptions(ctx, FrameId::Init);
+        let init = self.frame_assumptions(ctx, smt_ctx, FrameId::Init)?;
 
         // Disable bad states for `FROM_STEP`
         let neg_bad = ctx.not(self.from_step_bad_active);
@@ -596,6 +609,10 @@ impl BasePdr {
             fin_assumps,
             get_unsat_core,
         )?;
+
+        // Cleanup
+        let neg_init = ctx.not(init);
+        smt_ctx.assert(ctx, neg_init)?;
 
         if smt_res.0 == CheckSatResponse::Unknown {
             // Unknown query result: return error
@@ -626,11 +643,19 @@ impl BasePdr {
         gen_cube: Cube,
         rm_lits: impl IntoIterator<Item = ExprRef>,
     ) -> Result<Cube> {
+        // Proxies to clean up
+        let mut cleanup = vec![];
+
         // If generalized cube already doesn't intersect with initial states, just return
+        let cube_proxy = self.create_act_lit(ctx, smt_ctx)?;
         let cube_expr = gen_cube.to_expr(ctx);
         let cube_from = self.enc.expr_at_step(ctx, cube_expr, FROM_STEP);
+        let imp = ctx.implies(cube_proxy, cube_from);
+        smt_ctx.assert(ctx, imp)?;
+        cleanup.push(cube_proxy);
+
         if !self
-            .intersects_init(ctx, smt_ctx, sys, [cube_from], false)?
+            .intersects_init(ctx, smt_ctx, sys, [cube_proxy], false)?
             .0
         {
             return Ok(gen_cube);
@@ -656,21 +681,25 @@ impl BasePdr {
         let mut first_iter = true;
 
         // Original generalized cube at `FROM_STEP`
+        let cube_proxy = self.create_act_lit(ctx, smt_ctx)?;
         let cube_expr = gen_cube.to_expr(ctx);
         let cube_from = self.enc.expr_at_step(ctx, cube_expr, FROM_STEP);
+        let imp = ctx.implies(cube_proxy, cube_from);
+        smt_ctx.assert(ctx, imp)?;
+        cleanup.push(cube_proxy);
 
         loop {
             // Gather activation literals of original cube literals that could be dropped
             let mut assumps = lit_map.keys().copied().collect::<Vec<_>>();
 
             // Add original generalized cube to assumption
-            assumps.push(cube_from);
+            assumps.push(cube_proxy);
 
             let check_res = self.intersects_init(ctx, smt_ctx, sys, assumps, true)?;
 
             if check_res.0 && first_iter {
                 // Clean up activation literals
-                for &act in lit_map.keys() {
+                for &act in lit_map.keys().chain(cleanup.iter()) {
                     let neg_act = ctx.not(act);
                     smt_ctx.assert(ctx, neg_act)?;
                 }
@@ -709,7 +738,7 @@ impl BasePdr {
                 fin_lits.extend(lit_map.values().copied());
 
                 // Clean up activation literals
-                for &act in lit_map.keys() {
+                for &act in lit_map.keys().chain(cleanup.iter()) {
                     let neg_act = ctx.not(act);
                     smt_ctx.assert(ctx, neg_act)?;
                 }
@@ -736,11 +765,15 @@ impl BasePdr {
         query_type: RelIndType,
     ) -> Result<(CheckSatResponse, Option<Cube>)> {
         // Query assumptions
-        let mut assumptions = Vec::new();
+        let mut assumptions = vec![];
+
+        // Extra proxies to clean up
+        let mut cleanup = vec![];
 
         // Get frame assumption
-        let frame_assumption = self.frame_assumptions(ctx, cube.frame.decrement());
+        let frame_assumption = self.frame_assumptions(ctx, smt_ctx, cube.frame.decrement())?;
         assumptions.push(frame_assumption);
+        cleanup.push(frame_assumption);
 
         // Map between activation literal and original unstepped literal
         let mut lit_map = FxHashMap::default();
@@ -759,12 +792,18 @@ impl BasePdr {
 
         // Next step cube (expressed as `TO_STEP` literals)
         assumptions.extend(lit_map.keys());
+        cleanup.extend(lit_map.keys());
 
         // Current step negation cube
         if query_type == RelIndType::Extended {
+            let neg_cube_proxy = self.create_act_lit(ctx, smt_ctx)?;
             let neg_cube_expr = cube.cube.negate(ctx);
             let neg_cube_from = self.enc.expr_at_step(ctx, neg_cube_expr, FROM_STEP);
-            assumptions.push(neg_cube_from);
+            let imp = ctx.implies(neg_cube_proxy, neg_cube_from);
+            smt_ctx.assert(ctx, imp)?;
+
+            assumptions.push(neg_cube_proxy);
+            cleanup.push(neg_cube_proxy);
         }
 
         // Assert constraints hold after transition
@@ -813,7 +852,7 @@ impl BasePdr {
         };
 
         // Disable all created activation literals as cleanup
-        for &act in lit_map.keys() {
+        for act in cleanup {
             let neg_act = ctx.not(act);
             smt_ctx.assert(ctx, neg_act)?;
         }
@@ -848,7 +887,7 @@ impl BasePdr {
         let front = self.frontier();
 
         // Get frame assumptions for frontier frame
-        let front_assumption = self.frame_assumptions(ctx, front);
+        let front_assumption = self.frame_assumptions(ctx, smt_ctx, front)?;
 
         // Turn off constraint requirements for `TO_STEP`
         let neg_cons = ctx.not(self.to_step_constraints_active);
@@ -1055,15 +1094,21 @@ impl BasePdr {
             }
         }
 
+        let inf_assumption = self.frame_assumptions(ctx, smt_ctx, FrameId::Infinite)?;
+
         // Try to propagate all blocked cubes in the last finite frame into the infinite frame
         for cube in std::mem::take(&mut self[front].cubes) {
-            let inf_assumption = self.frame_assumptions(ctx, FrameId::Infinite);
-
+            let clause_proxy = self.create_act_lit(ctx, smt_ctx)?;
             let clause_expr = cube.negate(ctx);
             let clause_from = self.enc.expr_at_step(ctx, clause_expr, FROM_STEP);
+            let clause_imp = ctx.implies(clause_proxy, clause_from);
+            smt_ctx.assert(ctx, clause_imp)?;
 
+            let cube_proxy = self.create_act_lit(ctx, smt_ctx)?;
             let cube_expr = cube.to_expr(ctx);
             let cube_to = self.enc.expr_at_step(ctx, cube_expr, TO_STEP);
+            let cube_imp = ctx.implies(cube_proxy, cube_to);
+            smt_ctx.assert(ctx, cube_imp)?;
 
             // Disable `FROM_STEP` bad states
             let neg_bad = ctx.not(self.from_step_bad_active);
@@ -1077,14 +1122,20 @@ impl BasePdr {
                 &mut self.enc,
                 vec![
                     inf_assumption,
-                    clause_from,
-                    cube_to,
+                    clause_proxy,
+                    cube_proxy,
                     self.to_step_constraints_active,
                     neg_bad,
                 ],
                 false,
             )?
             .0;
+
+            // Cleanup
+            let neg_clause_proxy = ctx.not(clause_proxy);
+            let neg_cube_proxy = ctx.not(cube_proxy);
+            smt_ctx.assert(ctx, neg_clause_proxy)?;
+            smt_ctx.assert(ctx, neg_cube_proxy)?;
 
             if smt_res == CheckSatResponse::Unsat {
                 // If UNSAT, blocked cube can also be propagated to infinite frame

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -526,7 +526,12 @@ impl BasePdr {
     /// # Returns
     /// SMT expression asserting over-approximation of states reachable in `frame` steps
     /// (i.e. state space of `frame`-th frame), stepped at pre-transition step
-    fn frame_assumptions(&mut self, ctx: &mut Context, smt_ctx: &mut impl SolverContext, frame_id: FrameId) -> Result<ExprRef> {
+    fn frame_assumptions(
+        &mut self,
+        ctx: &mut Context,
+        smt_ctx: &mut impl SolverContext,
+        frame_id: FrameId,
+    ) -> Result<ExprRef> {
         assert!(
             frame_id == FrameId::Init
                 || frame_id <= self.frontier()
@@ -658,6 +663,12 @@ impl BasePdr {
             .intersects_init(ctx, smt_ctx, sys, [cube_proxy], false)?
             .0
         {
+            // Clean up
+            for act in cleanup {
+                let neg_act = ctx.not(act);
+                smt_ctx.assert(ctx, neg_act)?;
+            }
+
             return Ok(gen_cube);
         }
 
@@ -677,16 +688,10 @@ impl BasePdr {
             lit_map.insert(act, lit);
         }
 
+        cleanup.extend(lit_map.keys());
+
         // Flag for first iteration
         let mut first_iter = true;
-
-        // Original generalized cube at `FROM_STEP`
-        let cube_proxy = self.create_act_lit(ctx, smt_ctx)?;
-        let cube_expr = gen_cube.to_expr(ctx);
-        let cube_from = self.enc.expr_at_step(ctx, cube_expr, FROM_STEP);
-        let imp = ctx.implies(cube_proxy, cube_from);
-        smt_ctx.assert(ctx, imp)?;
-        cleanup.push(cube_proxy);
 
         loop {
             // Gather activation literals of original cube literals that could be dropped
@@ -699,7 +704,7 @@ impl BasePdr {
 
             if check_res.0 && first_iter {
                 // Clean up activation literals
-                for &act in lit_map.keys().chain(cleanup.iter()) {
+                for act in cleanup {
                     let neg_act = ctx.not(act);
                     smt_ctx.assert(ctx, neg_act)?;
                 }
@@ -724,21 +729,13 @@ impl BasePdr {
             // Remove all candidate literals not in UNSAT core
             lit_map.retain(|e, _| gen_lits.contains(e));
 
-            // Permanently disable literals that were removed
-            for &act in &prev_acts {
-                if !lit_map.contains_key(&act) {
-                    let neg_act = ctx.not(act);
-                    smt_ctx.assert(ctx, neg_act)?;
-                }
-            }
-
             if lit_map.len() == prev_acts.len() {
                 // If no literals are removed, then fixpoint reached
                 let mut fin_lits = gen_cube.literals;
                 fin_lits.extend(lit_map.values().copied());
 
                 // Clean up activation literals
-                for &act in lit_map.keys().chain(cleanup.iter()) {
+                for act in cleanup {
                     let neg_act = ctx.not(act);
                     smt_ctx.assert(ctx, neg_act)?;
                 }
@@ -892,15 +889,21 @@ impl BasePdr {
         // Turn off constraint requirements for `TO_STEP`
         let neg_cons = ctx.not(self.to_step_constraints_active);
 
-        // Run query SAT?[R_N /\ \neg P]
-        match query(
+        let res = query(
             ctx,
             smt_ctx,
             sys,
             &mut self.enc,
             vec![front_assumption, self.from_step_bad_active, neg_cons], // Assert bad states at `FROM_STEP`
             false,
-        )? {
+        )?;
+
+        // Clean up
+        let neg_proxy = ctx.not(front_assumption);
+        smt_ctx.assert(ctx, neg_proxy)?;
+
+        // Run query SAT?[R_N /\ \neg P]
+        match res {
             (CheckSatResponse::Sat, Some(cube)) => {
                 // Safety property violation found: return witness cube
                 Ok(Some(cube))
@@ -1094,7 +1097,7 @@ impl BasePdr {
             }
         }
 
-        let inf_assumption = self.frame_assumptions(ctx, smt_ctx, FrameId::Infinite)?;
+        let inf_assump = self.frame_assumptions(ctx, smt_ctx, FrameId::Infinite)?;
 
         // Try to propagate all blocked cubes in the last finite frame into the infinite frame
         for cube in std::mem::take(&mut self[front].cubes) {
@@ -1121,7 +1124,7 @@ impl BasePdr {
                 sys,
                 &mut self.enc,
                 vec![
-                    inf_assumption,
+                    inf_assump,
                     clause_proxy,
                     cube_proxy,
                     self.to_step_constraints_active,
@@ -1131,7 +1134,7 @@ impl BasePdr {
             )?
             .0;
 
-            // Cleanup
+            // Clean up
             let neg_clause_proxy = ctx.not(clause_proxy);
             let neg_cube_proxy = ctx.not(cube_proxy);
             smt_ctx.assert(ctx, neg_clause_proxy)?;
@@ -1152,6 +1155,10 @@ impl BasePdr {
                 self[front].cubes.push(cube);
             }
         }
+
+        // Clean up
+        let neg_inf_proxy = ctx.not(inf_assump);
+        smt_ctx.assert(ctx, neg_inf_proxy)?;
 
         // Inductive invariant not found
         Ok(false)

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -25,6 +25,9 @@ const MAX_FRAMES: usize = 1000;
 /// Activation literal prefix
 const ACT_LIT_PREFIX: &str = "__pdr_act_";
 
+/// Activation literal prefix for frames
+const FRAME_LIT_PREFIX: &str = "__pdr_frame_act_";
+
 // -------------------------------------------------------------------------------------------------
 // Core PDR data structures
 // -------------------------------------------------------------------------------------------------
@@ -339,7 +342,7 @@ struct ActLitScope {
 impl ActLitScope {
     /// Permanently disable all activation literals in this scope
     fn release(&mut self, ctx: &mut Context, smt_ctx: &mut impl SolverContext) -> Result<()> {
-        for &lit in &self.act_lits {
+        for lit in self.act_lits.drain(..) {
             let neg_lit = ctx.not(lit);
             smt_ctx.assert(ctx, neg_lit)?;
         }
@@ -368,8 +371,8 @@ impl ActLitPool {
         Ok(lit)
     }
 
-    /// Create a temporary activation literal that is coupled with [body] (i.e. `act => body`)
-    /// and registered into [scope]
+    /// Create a temporary activation literal that is coupled with `body` (i.e. `act => body`)
+    /// and registered into `scope`
     fn imply(
         &mut self,
         ctx: &mut Context,
@@ -377,7 +380,7 @@ impl ActLitPool {
         scope: &mut ActLitScope,
         body: ExprRef,
     ) -> Result<ExprRef> {
-        // If solver supports compound expression assumptios, then activation literals
+        // If solver supports compound expression assumptions, then activation literals
         // are not needed
         if smt_ctx.supports_check_assuming_exprs() {
             return Ok(body);
@@ -397,7 +400,7 @@ impl ActLitPool {
     /// with the associated stepped cube literal
     ///
     /// # Precondition
-    /// [stepped_lit] must be stepped
+    /// `stepped_lit` must be stepped
     ///
     /// # Note
     /// Produced activation literal remains in global solver context. This is sound since
@@ -413,18 +416,18 @@ impl ActLitPool {
             return Ok(*act);
         }
 
-        // Create `act => stepped_lit` and assert in solverjj
+        // Create `act => stepped_lit` and assert in solver
         let act = self.create(ctx, smt_ctx)?;
         let imp = ctx.implies(act, stepped_lit);
         smt_ctx.assert(ctx, imp)?;
 
-        // Register steppped literal and its activation literal in cache
+        // Register stepped literal and its activation literal in cache
         self.step_lit_cache.insert(stepped_lit, act);
         Ok(act)
     }
 }
 
-/// Execute closure with a fresh [`ActScope`] and clean up all used activation literals in the end
+/// Execute closure with a fresh [`ActLitScope`] and clean up all used activation literals in the end
 fn with_act_scope<S: SolverContext, T>(
     ctx: &mut Context,
     smt_ctx: &mut S,
@@ -959,7 +962,7 @@ impl BasePdr {
     fn add_frame(&mut self, ctx: &mut Context, smt_ctx: &mut impl SolverContext) -> Result<()> {
         // Create new activation literal for frame
         let act = ctx.bv_symbol(
-            format!("__pdr_frame_act_{}", self.frames.len() + 1).as_str(),
+            format!("{FRAME_LIT_PREFIX}{}", self.frames.len() + 1).as_str(),
             1,
         );
         smt_ctx.declare_const(ctx, act)?;
@@ -1140,49 +1143,53 @@ impl BasePdr {
 
             // Try to propagate all blocked cubes in the last finite frame into the infinite frame
             for cube in std::mem::take(&mut self[front].cubes) {
-                let clause_expr = cube.negate(ctx);
-                let clause_from = self.enc.expr_at_step(ctx, clause_expr, FROM_STEP);
-                let clause_proxy = self.pool.imply(ctx, smt_ctx, scope, clause_from)?;
+                with_act_scope(ctx, smt_ctx, |ctx, smt_ctx, scope| {
+                    let clause_expr = cube.negate(ctx);
+                    let clause_from = self.enc.expr_at_step(ctx, clause_expr, FROM_STEP);
+                    let clause_proxy = self.pool.imply(ctx, smt_ctx, scope, clause_from)?;
 
-                let cube_expr = cube.to_expr(ctx);
-                let cube_to = self.enc.expr_at_step(ctx, cube_expr, TO_STEP);
-                let cube_proxy = self.pool.imply(ctx, smt_ctx, scope, cube_to)?;
+                    let cube_expr = cube.to_expr(ctx);
+                    let cube_to = self.enc.expr_at_step(ctx, cube_expr, TO_STEP);
+                    let cube_proxy = self.pool.imply(ctx, smt_ctx, scope, cube_to)?;
 
-                // Disable `FROM_STEP` bad states
-                let neg_bad = ctx.not(self.from_step_bad_active);
+                    // Disable `FROM_STEP` bad states
+                    let neg_bad = ctx.not(self.from_step_bad_active);
 
-                // Run the query `SAT?[R_\infty /\ \neg c /\ T /\ c']`, asserting that the
-                // constraints hold at `TO_STEP`
-                let smt_res = query(
-                    ctx,
-                    smt_ctx,
-                    sys,
-                    &mut self.enc,
-                    vec![
-                        inf_assump,
-                        clause_proxy,
-                        cube_proxy,
-                        self.to_step_constraints_active,
-                        neg_bad,
-                    ],
-                    false,
-                )?
-                .0;
-
-                if smt_res == CheckSatResponse::Unsat {
-                    // If UNSAT, blocked cube can also be propagated to infinite frame
-                    self.add_blocked_cube(
+                    // Run the query `SAT?[R_\infty /\ \neg c /\ T /\ c']`, asserting that the
+                    // constraints hold at `TO_STEP`
+                    let smt_res = query(
                         ctx,
                         smt_ctx,
-                        TimedCube {
-                            cube,
-                            frame: FrameId::Infinite,
-                        },
-                    )?;
-                } else {
-                    // Else, blocked cube can only stay in finite frame
-                    self[front].cubes.push(cube);
-                }
+                        sys,
+                        &mut self.enc,
+                        vec![
+                            inf_assump,
+                            clause_proxy,
+                            cube_proxy,
+                            self.to_step_constraints_active,
+                            neg_bad,
+                        ],
+                        false,
+                    )?
+                    .0;
+
+                    if smt_res == CheckSatResponse::Unsat {
+                        // If UNSAT, blocked cube can also be propagated to infinite frame
+                        self.add_blocked_cube(
+                            ctx,
+                            smt_ctx,
+                            TimedCube {
+                                cube,
+                                frame: FrameId::Infinite,
+                            },
+                        )?;
+                    } else {
+                        // Else, blocked cube can only stay in finite frame
+                        self[front].cubes.push(cube);
+                    }
+
+                    Ok(())
+                })?;
             }
 
             Ok(())
@@ -1228,6 +1235,9 @@ pub fn pdr(
             )? {
                 // Reset solver
                 smt_ctx.restart()?;
+
+                // Clear the stepped literal cache
+                state.pool.step_lit_cache.clear();
 
                 // Cube could not be blocked: construct witness from BMC instance and fail
                 let ModelCheckResult::Fail(wit) =

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -327,6 +327,121 @@ impl<E: TransitionSystemEncoding> PdrEncodingWrapper<E> {
 }
 
 // -------------------------------------------------------------------------------------------------
+// Activation Literal Pool
+// -------------------------------------------------------------------------------------------------
+
+/// Collection of activation literals used in scope
+#[derive(Default)]
+struct ActLitScope {
+    act_lits: Vec<ExprRef>,
+}
+
+impl ActLitScope {
+    /// Permanently disable all activation literals in this scope
+    fn release(&mut self, ctx: &mut Context, smt_ctx: &mut impl SolverContext) -> Result<()> {
+        for &lit in &self.act_lits {
+            let neg_lit = ctx.not(lit);
+            smt_ctx.assert(ctx, neg_lit)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct ActLitPool {
+    /// Activation literal ID tracker
+    next_act_id: u64,
+
+    /// Cache mapping from stepped literal to activation literal
+    step_lit_cache: FxHashMap<ExprRef, ExprRef>,
+}
+
+impl ActLitPool {
+    /// Create a new activation literal
+    fn create(&mut self, ctx: &mut Context, smt_ctx: &mut impl SolverContext) -> Result<ExprRef> {
+        // Intern activation literal and define in solver
+        let lit = ctx.bv_symbol(format!("{ACT_LIT_PREFIX}{}", self.next_act_id).as_str(), 1);
+        smt_ctx.declare_const(ctx, lit)?;
+
+        // Update activation literal counter and return
+        self.next_act_id += 1;
+        Ok(lit)
+    }
+
+    /// Create a temporary activation literal that is coupled with [body] (i.e. `act => body`)
+    /// and registered into [scope]
+    fn imply(
+        &mut self,
+        ctx: &mut Context,
+        smt_ctx: &mut impl SolverContext,
+        scope: &mut ActLitScope,
+        body: ExprRef,
+    ) -> Result<ExprRef> {
+        // If solver supports compound expression assumptios, then activation literals
+        // are not needed
+        if smt_ctx.supports_check_assuming_exprs() {
+            return Ok(body);
+        }
+
+        // Create `act => body` and assert in solver
+        let act = self.create(ctx, smt_ctx)?;
+        let imp = ctx.implies(act, body);
+        smt_ctx.assert(ctx, imp)?;
+
+        // Register activation literal in scope
+        scope.act_lits.push(act);
+        Ok(act)
+    }
+
+    /// Create an activation literal for a stepped cube literal, caching the activation literal
+    /// with the associated stepped cube literal
+    ///
+    /// # Precondition
+    /// [stepped_lit] must be stepped
+    ///
+    /// # Note
+    /// Produced activation literal remains in global solver context. This is sound since
+    /// `act => stepped_lit` is a permanent fact.
+    fn step_lit_act(
+        &mut self,
+        ctx: &mut Context,
+        smt_ctx: &mut impl SolverContext,
+        stepped_lit: ExprRef,
+    ) -> Result<ExprRef> {
+        // Check cache for activation literal
+        if let Some(act) = self.step_lit_cache.get(&stepped_lit) {
+            return Ok(*act);
+        }
+
+        // Create `act => stepped_lit` and assert in solverjj
+        let act = self.create(ctx, smt_ctx)?;
+        let imp = ctx.implies(act, stepped_lit);
+        smt_ctx.assert(ctx, imp)?;
+
+        // Register steppped literal and its activation literal in cache
+        self.step_lit_cache.insert(stepped_lit, act);
+        Ok(act)
+    }
+}
+
+/// Execute closure with a fresh [`ActScope`] and clean up all used activation literals in the end
+fn with_act_scope<S: SolverContext, T>(
+    ctx: &mut Context,
+    smt_ctx: &mut S,
+    f: impl FnOnce(&mut Context, &mut S, &mut ActLitScope) -> Result<T>,
+) -> Result<T> {
+    // Create new activation literal scope, run closure, and clean up used activation literals
+    let mut scope = ActLitScope::default();
+    let res = f(ctx, smt_ctx, &mut scope);
+    let cleanup = scope.release(ctx, smt_ctx);
+
+    match res {
+        Ok(v) => cleanup.map(|()| v), // Return result from closure, noting cleanup errors
+        Err(e) => Err(e),             // Return error produced by closure
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
 // Core PDR
 // -------------------------------------------------------------------------------------------------
 
@@ -364,8 +479,8 @@ struct BasePdr {
     /// Frame trace containing frames with blocked cubes
     frames: Vec<Frame>,
 
-    /// Incrementing counter for creating unique frame activation literal IDs
-    next_act_id: u64,
+    /// Activation literal pool
+    pool: ActLitPool,
 
     /// PDR runtime options
     opts: PdrOptions,
@@ -501,26 +616,11 @@ impl BasePdr {
             init_frame: init_act,
             inf_frame,
             frames: vec![], // Index consistency taken care by indexing function
-            next_act_id: 0,
+            pool: ActLitPool::default(),
             opts: PdrOptions {
                 disable_unsat_cores,
             },
         })
-    }
-
-    /// # Returns
-    /// New activation literal
-    fn create_act_lit(
-        &mut self,
-        ctx: &mut Context,
-        smt_ctx: &mut impl SolverContext,
-    ) -> Result<ExprRef> {
-        let act = ctx.bv_symbol(format!("{ACT_LIT_PREFIX}{}", self.next_act_id).as_str(), 1);
-        self.next_act_id += 1;
-
-        smt_ctx.declare_const(ctx, act)?;
-
-        Ok(act)
     }
 
     /// # Returns
@@ -530,6 +630,7 @@ impl BasePdr {
         &mut self,
         ctx: &mut Context,
         smt_ctx: &mut impl SolverContext,
+        scope: &mut ActLitScope,
         frame_id: FrameId,
     ) -> Result<ExprRef> {
         assert!(
@@ -540,15 +641,11 @@ impl BasePdr {
 
         // Special case: for init frame, just return initial activation literal
         if frame_id == FrameId::Init {
-            let init_proxy = self.create_act_lit(ctx, smt_ctx)?;
             let init_assump = self.iter().fold(self.init_frame, |acc, id| {
                 let neg_act = ctx.not(self[id].act);
                 ctx.and(acc, neg_act)
             });
-            let imp = ctx.implies(init_proxy, init_assump);
-            smt_ctx.assert(ctx, imp)?;
-
-            return Ok(init_proxy);
+            return self.pool.imply(ctx, smt_ctx, scope, init_assump);
         }
 
         // Conjunct all blocked cubes in this frame and higher (since all blocked
@@ -566,14 +663,7 @@ impl BasePdr {
                 ctx.and(acc, neg_act)
             }
         });
-
-        // Introduce proxy variable for frame assumptions (i.e. x = frame_assump)
-        // to avoid compound SMT expression
-        let proxy = self.create_act_lit(ctx, smt_ctx)?;
-        let imp = ctx.implies(proxy, frame_assump);
-        smt_ctx.assert(ctx, imp)?;
-
-        Ok(proxy)
+        self.pool.imply(ctx, smt_ctx, scope, frame_assump)
     }
 
     /// Check if assumptions intersect with the initial states
@@ -592,43 +682,41 @@ impl BasePdr {
         assumptions: impl IntoIterator<Item = ExprRef>,
         get_unsat_core: bool,
     ) -> Result<(bool, Option<Cube>)> {
-        // Initial frame
-        let init = self.frame_assumptions(ctx, smt_ctx, FrameId::Init)?;
+        with_act_scope(ctx, smt_ctx, |ctx, smt_ctx, scope| {
+            // Initial frame
+            let init = self.frame_assumptions(ctx, smt_ctx, scope, FrameId::Init)?;
 
-        // Disable bad states for `FROM_STEP`
-        let neg_bad = ctx.not(self.from_step_bad_active);
+            // Disable bad states for `FROM_STEP`
+            let neg_bad = ctx.not(self.from_step_bad_active);
 
-        // Disable constraints for `TO_STEP`
-        let neg_cons = ctx.not(self.to_step_constraints_active);
+            // Disable constraints for `TO_STEP`
+            let neg_cons = ctx.not(self.to_step_constraints_active);
 
-        // Complete assumptions
-        let mut fin_assumps = vec![init, neg_cons, neg_bad];
-        fin_assumps.extend(assumptions);
+            // Complete assumptions
+            let mut fin_assumps = vec![init, neg_cons, neg_bad];
+            fin_assumps.extend(assumptions);
 
-        // Run query `SAT?[R_0 /\ c]`
-        let smt_res = query(
-            ctx,
-            smt_ctx,
-            sys,
-            &mut self.enc,
-            fin_assumps,
-            get_unsat_core,
-        )?;
+            // Run query `SAT?[R_0 /\ c]`
+            let smt_res = query(
+                ctx,
+                smt_ctx,
+                sys,
+                &mut self.enc,
+                fin_assumps,
+                get_unsat_core,
+            )?;
 
-        // Cleanup
-        let neg_init = ctx.not(init);
-        smt_ctx.assert(ctx, neg_init)?;
-
-        if smt_res.0 == CheckSatResponse::Unknown {
-            // Unknown query result: return error
-            Err(Error::UnexpectedResponse(
-                "`intersects_init` in `BasePdr`".into(),
-                "unknown query".into(),
-            ))
-        } else {
-            // Else, only assert non-intersection if query was UNSAT
-            Ok((smt_res.0 == CheckSatResponse::Sat, smt_res.1))
-        }
+            if smt_res.0 == CheckSatResponse::Unknown {
+                // Unknown query result: return error
+                Err(Error::UnexpectedResponse(
+                    "`intersects_init` in `BasePdr`".into(),
+                    "unknown query".into(),
+                ))
+            } else {
+                // Else, only assert non-intersection if query was UNSAT
+                Ok((smt_res.0 == CheckSatResponse::Sat, smt_res.1))
+            }
+        })
     }
 
     /// "Fix" generalized cube by restoring enough removed literals until non-intersection
@@ -648,103 +736,72 @@ impl BasePdr {
         gen_cube: Cube,
         rm_lits: impl IntoIterator<Item = ExprRef>,
     ) -> Result<Cube> {
-        // Proxies to clean up
-        let mut cleanup = vec![];
+        with_act_scope(ctx, smt_ctx, |ctx, smt_ctx, scope| {
+            // If generalized cube already doesn't intersect with initial states, just return
+            let cube_expr = gen_cube.to_expr(ctx);
+            let cube_from = self.enc.expr_at_step(ctx, cube_expr, FROM_STEP);
+            let cube_proxy = self.pool.imply(ctx, smt_ctx, scope, cube_from)?;
 
-        // If generalized cube already doesn't intersect with initial states, just return
-        let cube_proxy = self.create_act_lit(ctx, smt_ctx)?;
-        let cube_expr = gen_cube.to_expr(ctx);
-        let cube_from = self.enc.expr_at_step(ctx, cube_expr, FROM_STEP);
-        let imp = ctx.implies(cube_proxy, cube_from);
-        smt_ctx.assert(ctx, imp)?;
-        cleanup.push(cube_proxy);
-
-        if !self
-            .intersects_init(ctx, smt_ctx, sys, [cube_proxy], false)?
-            .0
-        {
-            // Clean up
-            for act in cleanup {
-                let neg_act = ctx.not(act);
-                smt_ctx.assert(ctx, neg_act)?;
+            if !self
+                .intersects_init(ctx, smt_ctx, sys, [cube_proxy], false)?
+                .0
+            {
+                return Ok(gen_cube);
             }
 
-            return Ok(gen_cube);
-        }
+            // Create activation literals for original cube literals (predicates) that were
+            // dropped during generalization
+            let mut lit_map = FxHashMap::default();
+            for lit in rm_lits {
+                // Create activation literal implication and add to mapping
+                let expr_from = self.enc.expr_at_step(ctx, lit, FROM_STEP);
+                let act = self.pool.step_lit_act(ctx, smt_ctx, expr_from)?;
+                lit_map.insert(act, lit);
+            }
 
-        // Create activation literals for original cube literals (predicates) that were
-        // dropped during generalization
-        let mut lit_map = FxHashMap::default();
-        for lit in rm_lits {
-            // Create activation literal implication
-            let act = self.create_act_lit(ctx, smt_ctx)?;
-            let expr_from = self.enc.expr_at_step(ctx, lit, FROM_STEP);
-            let imp = ctx.implies(act, expr_from);
+            // Flag for first iteration
+            let mut first_iter = true;
 
-            // Assert in solver
-            smt_ctx.assert(ctx, imp)?;
+            loop {
+                // Gather activation literals of original cube literals that could be dropped
+                let mut assumps = lit_map.keys().copied().collect::<Vec<_>>();
 
-            // Add mapping
-            lit_map.insert(act, lit);
-        }
+                // Add original generalized cube to assumption
+                assumps.push(cube_proxy);
 
-        cleanup.extend(lit_map.keys());
+                let check_res = self.intersects_init(ctx, smt_ctx, sys, assumps, true)?;
 
-        // Flag for first iteration
-        let mut first_iter = true;
-
-        loop {
-            // Gather activation literals of original cube literals that could be dropped
-            let mut assumps = lit_map.keys().copied().collect::<Vec<_>>();
-
-            // Add original generalized cube to assumption
-            assumps.push(cube_proxy);
-
-            let check_res = self.intersects_init(ctx, smt_ctx, sys, assumps, true)?;
-
-            if check_res.0 && first_iter {
-                // Clean up activation literals
-                for act in cleanup {
-                    let neg_act = ctx.not(act);
-                    smt_ctx.assert(ctx, neg_act)?;
+                if check_res.0 && first_iter {
+                    // If first iteration, original cube must truly intersect with init frame
+                    return Err(Error::UnexpectedResponse(
+                        "`fix_gen_cube` in `BasePdr`".into(),
+                        "original cube intersects with init".into(),
+                    ));
                 }
 
-                // If first iteration, original cube must truly intersect with init frame
-                return Err(Error::UnexpectedResponse(
-                    "`fix_gen_cube` in `BasePdr`".into(),
-                    "original cube intersects with init".into(),
-                ));
-            }
+                // All removed literals should not be in UNSAT core
+                assert!(!check_res.0);
 
-            // All removed literals should not be in UNSAT core
-            assert!(!check_res.0);
+                // Store previous number of literals
+                let prev_acts = lit_map.keys().copied().collect::<Vec<_>>();
 
-            // Store previous number of literals
-            let prev_acts = lit_map.keys().copied().collect::<Vec<_>>();
+                // Collect all literals in the UNSAT core
+                let ex_cube = check_res.1.unwrap();
+                let gen_lits = ex_cube.literals.iter().collect::<FxHashSet<_>>();
 
-            // Collect all literals in the UNSAT core
-            let ex_cube = check_res.1.unwrap();
-            let gen_lits = ex_cube.literals.iter().collect::<FxHashSet<_>>();
+                // Remove all candidate literals not in UNSAT core
+                lit_map.retain(|e, _| gen_lits.contains(e));
 
-            // Remove all candidate literals not in UNSAT core
-            lit_map.retain(|e, _| gen_lits.contains(e));
-
-            if lit_map.len() == prev_acts.len() {
-                // If no literals are removed, then fixpoint reached
-                let mut fin_lits = gen_cube.literals;
-                fin_lits.extend(lit_map.values().copied());
-
-                // Clean up activation literals
-                for act in cleanup {
-                    let neg_act = ctx.not(act);
-                    smt_ctx.assert(ctx, neg_act)?;
+                if lit_map.len() == prev_acts.len() {
+                    // If no literals are removed, then fixpoint reached
+                    let mut fin_lits = gen_cube.literals;
+                    fin_lits.extend(lit_map.values().copied());
+                    return Ok(Cube { literals: fin_lits });
                 }
 
-                return Ok(Cube { literals: fin_lits });
+                first_iter = false;
             }
-
-            first_iter = false;
-        }
+        })
     }
 
     /// Run relative inductiveness query
@@ -761,100 +818,80 @@ impl BasePdr {
         cube: &TimedCube,
         query_type: RelIndType,
     ) -> Result<(CheckSatResponse, Option<Cube>)> {
-        // Query assumptions
-        let mut assumptions = vec![];
+        with_act_scope(ctx, smt_ctx, |ctx, smt_ctx, scope| {
+            // Query assumptions
+            let mut assumptions = vec![];
 
-        // Extra proxies to clean up
-        let mut cleanup = vec![];
+            // Get frame assumption
+            let frame_assumption =
+                self.frame_assumptions(ctx, smt_ctx, scope, cube.frame.decrement())?;
+            assumptions.push(frame_assumption);
 
-        // Get frame assumption
-        let frame_assumption = self.frame_assumptions(ctx, smt_ctx, cube.frame.decrement())?;
-        assumptions.push(frame_assumption);
-        cleanup.push(frame_assumption);
+            // Map between activation literal and original unstepped literal
+            let mut lit_map = FxHashMap::default();
+            for &lit in &cube.cube.literals {
+                // Activate `TO_STEP` literal and add to mapping
+                let expr_to = self.enc.expr_at_step(ctx, lit, TO_STEP);
+                let act = self.pool.step_lit_act(ctx, smt_ctx, expr_to)?;
+                lit_map.insert(act, lit);
+            }
 
-        // Map between activation literal and original unstepped literal
-        let mut lit_map = FxHashMap::default();
-        for &lit in &cube.cube.literals {
-            // Activate `TO_STEP` literal
-            let act = self.create_act_lit(ctx, smt_ctx)?;
-            let expr_to = self.enc.expr_at_step(ctx, lit, TO_STEP);
-            let imp = ctx.implies(act, expr_to);
+            // Next step cube (expressed as `TO_STEP` literals)
+            assumptions.extend(lit_map.keys());
 
-            // Permanently assert in solver
-            smt_ctx.assert(ctx, imp)?;
+            // Current step negation cube
+            if query_type == RelIndType::Extended {
+                let neg_cube_expr = cube.cube.negate(ctx);
+                let neg_cube_from = self.enc.expr_at_step(ctx, neg_cube_expr, FROM_STEP);
+                let neg_cube_proxy = self.pool.imply(ctx, smt_ctx, scope, neg_cube_from)?;
+                assumptions.push(neg_cube_proxy);
+            }
 
-            // Add mapping
-            lit_map.insert(act, lit);
-        }
+            // Assert constraints hold after transition
+            assumptions.push(self.to_step_constraints_active);
 
-        // Next step cube (expressed as `TO_STEP` literals)
-        assumptions.extend(lit_map.keys());
-        cleanup.extend(lit_map.keys());
+            // Disable `FROM_STEP` bad state assertion
+            assumptions.push(ctx.not(self.from_step_bad_active));
 
-        // Current step negation cube
-        if query_type == RelIndType::Extended {
-            let neg_cube_proxy = self.create_act_lit(ctx, smt_ctx)?;
-            let neg_cube_expr = cube.cube.negate(ctx);
-            let neg_cube_from = self.enc.expr_at_step(ctx, neg_cube_expr, FROM_STEP);
-            let imp = ctx.implies(neg_cube_proxy, neg_cube_from);
-            smt_ctx.assert(ctx, imp)?;
+            // Run SMT query
+            let smt_res = query(
+                ctx,
+                smt_ctx,
+                sys,
+                &mut self.enc,
+                assumptions,
+                !self.opts.disable_unsat_cores,
+            )?;
 
-            assumptions.push(neg_cube_proxy);
-            cleanup.push(neg_cube_proxy);
-        }
+            // Extract candidate cube literals if generalized cube was created
+            if smt_res.0 == CheckSatResponse::Unsat
+                && let Some(genr) = smt_res.1
+            {
+                // Literals in UNSAT core
+                let gen_lits = genr
+                    .literals
+                    .iter()
+                    .filter_map(|&lit| lit_map.get(&lit).copied())
+                    .collect::<FxHashSet<_>>();
 
-        // Assert constraints hold after transition
-        assumptions.push(self.to_step_constraints_active);
+                // Literals not in UNSAT core
+                let rm_lits = lit_map
+                    .values()
+                    .copied()
+                    .filter(|e| !gen_lits.contains(e))
+                    .collect::<Vec<_>>();
 
-        // Disable `FROM_STEP` bad state assertion
-        assumptions.push(ctx.not(self.from_step_bad_active));
+                // Make generalized cube not intersect initial states
+                let gen_cube = Cube {
+                    literals: gen_lits.into_iter().collect(),
+                };
+                let fixed = self.fix_gen_cube(ctx, smt_ctx, sys, gen_cube, rm_lits)?;
 
-        // Run SMT query
-        let smt_res = query(
-            ctx,
-            smt_ctx,
-            sys,
-            &mut self.enc,
-            assumptions,
-            !self.opts.disable_unsat_cores,
-        )?;
-
-        // Extract candidate cube literals if generalized cube was created
-        let res = if smt_res.0 == CheckSatResponse::Unsat
-            && let Some(genr) = smt_res.1
-        {
-            // Literals in UNSAT core
-            let gen_lits = genr
-                .literals
-                .iter()
-                .filter_map(|&lit| lit_map.get(&lit).copied())
-                .collect::<FxHashSet<_>>();
-
-            // Literals not in UNSAT core
-            let rm_lits = lit_map
-                .values()
-                .copied()
-                .filter(|e| !gen_lits.contains(e))
-                .collect::<Vec<_>>();
-
-            // Make generalized cube not intersect initial states
-            let gen_cube = Cube {
-                literals: gen_lits.into_iter().collect(),
-            };
-            let fixed = self.fix_gen_cube(ctx, smt_ctx, sys, gen_cube, rm_lits)?;
-
-            Ok((CheckSatResponse::Unsat, Some(fixed)))
-        } else {
-            Ok(smt_res)
-        };
-
-        // Disable all created activation literals as cleanup
-        for act in cleanup {
-            let neg_act = ctx.not(act);
-            smt_ctx.assert(ctx, neg_act)?;
-        }
-
-        res
+                Ok((CheckSatResponse::Unsat, Some(fixed)))
+            } else {
+                Ok(smt_res)
+            }
+        })
     }
 
     /// Frame identifier for frontier frame
@@ -880,50 +917,52 @@ impl BasePdr {
         smt_ctx: &mut impl SolverContext,
         sys: &TransitionSystem,
     ) -> Result<Option<Cube>> {
-        // Get frontier frame identifier
-        let front = self.frontier();
+        with_act_scope(ctx, smt_ctx, |ctx, smt_ctx, scope| {
+            // Get frontier frame identifier
+            let front = self.frontier();
 
-        // Get frame assumptions for frontier frame
-        let front_assumption = self.frame_assumptions(ctx, smt_ctx, front)?;
+            // Get frame assumptions for frontier frame
+            let front_assumption = self.frame_assumptions(ctx, smt_ctx, scope, front)?;
 
-        // Turn off constraint requirements for `TO_STEP`
-        let neg_cons = ctx.not(self.to_step_constraints_active);
+            // Turn off constraint requirements for `TO_STEP`
+            let neg_cons = ctx.not(self.to_step_constraints_active);
 
-        let res = query(
-            ctx,
-            smt_ctx,
-            sys,
-            &mut self.enc,
-            vec![front_assumption, self.from_step_bad_active, neg_cons], // Assert bad states at `FROM_STEP`
-            false,
-        )?;
+            let res = query(
+                ctx,
+                smt_ctx,
+                sys,
+                &mut self.enc,
+                vec![front_assumption, self.from_step_bad_active, neg_cons], // Assert bad states at `FROM_STEP`
+                false,
+            )?;
 
-        // Clean up
-        let neg_proxy = ctx.not(front_assumption);
-        smt_ctx.assert(ctx, neg_proxy)?;
-
-        // Run query SAT?[R_N /\ \neg P]
-        match res {
-            (CheckSatResponse::Sat, Some(cube)) => {
-                // Safety property violation found: return witness cube
-                Ok(Some(cube))
-            }
-            (CheckSatResponse::Unsat, _) => Ok(None), // No safety property violation found
-            (CheckSatResponse::Unknown, _) => Err(
-                // Unknown query result: return error for soundness
-                Error::UnexpectedResponse(
-                    "`get_bad_cube` in `BasePdr`".into(),
-                    "unknown query".into(),
+            // Run query SAT?[R_N /\ \neg P]
+            match res {
+                (CheckSatResponse::Sat, Some(cube)) => {
+                    // Safety property violation found: return witness cube
+                    Ok(Some(cube))
+                }
+                (CheckSatResponse::Unsat, _) => Ok(None), // No safety property violation found
+                (CheckSatResponse::Unknown, _) => Err(
+                    // Unknown query result: return error for soundness
+                    Error::UnexpectedResponse(
+                        "`get_bad_cube` in `BasePdr`".into(),
+                        "unknown query".into(),
+                    ),
                 ),
-            ),
-            _ => unreachable!(),
-        }
+                _ => unreachable!(),
+            }
+        })
     }
 
     /// Adds empty frame to frame trace
     fn add_frame(&mut self, ctx: &mut Context, smt_ctx: &mut impl SolverContext) -> Result<()> {
         // Create new activation literal for frame
-        let act = self.create_act_lit(ctx, smt_ctx)?;
+        let act = ctx.bv_symbol(
+            format!("__pdr_frame_act_{}", self.frames.len() + 1).as_str(),
+            1,
+        );
+        smt_ctx.declare_const(ctx, act)?;
 
         // Add new frame
         self.frames.push(Frame { act, cubes: vec![] });
@@ -946,7 +985,6 @@ impl BasePdr {
 
         // Add blocked cube to frame
         self[cube.frame].cubes.push(cube.cube);
-
         Ok(())
     }
 
@@ -1097,68 +1135,58 @@ impl BasePdr {
             }
         }
 
-        let inf_assump = self.frame_assumptions(ctx, smt_ctx, FrameId::Infinite)?;
+        with_act_scope(ctx, smt_ctx, |ctx, smt_ctx, scope| {
+            let inf_assump = self.frame_assumptions(ctx, smt_ctx, scope, FrameId::Infinite)?;
 
-        // Try to propagate all blocked cubes in the last finite frame into the infinite frame
-        for cube in std::mem::take(&mut self[front].cubes) {
-            let clause_proxy = self.create_act_lit(ctx, smt_ctx)?;
-            let clause_expr = cube.negate(ctx);
-            let clause_from = self.enc.expr_at_step(ctx, clause_expr, FROM_STEP);
-            let clause_imp = ctx.implies(clause_proxy, clause_from);
-            smt_ctx.assert(ctx, clause_imp)?;
+            // Try to propagate all blocked cubes in the last finite frame into the infinite frame
+            for cube in std::mem::take(&mut self[front].cubes) {
+                let clause_expr = cube.negate(ctx);
+                let clause_from = self.enc.expr_at_step(ctx, clause_expr, FROM_STEP);
+                let clause_proxy = self.pool.imply(ctx, smt_ctx, scope, clause_from)?;
 
-            let cube_proxy = self.create_act_lit(ctx, smt_ctx)?;
-            let cube_expr = cube.to_expr(ctx);
-            let cube_to = self.enc.expr_at_step(ctx, cube_expr, TO_STEP);
-            let cube_imp = ctx.implies(cube_proxy, cube_to);
-            smt_ctx.assert(ctx, cube_imp)?;
+                let cube_expr = cube.to_expr(ctx);
+                let cube_to = self.enc.expr_at_step(ctx, cube_expr, TO_STEP);
+                let cube_proxy = self.pool.imply(ctx, smt_ctx, scope, cube_to)?;
 
-            // Disable `FROM_STEP` bad states
-            let neg_bad = ctx.not(self.from_step_bad_active);
+                // Disable `FROM_STEP` bad states
+                let neg_bad = ctx.not(self.from_step_bad_active);
 
-            // Run the query `SAT?[R_\infty /\ \neg c /\ T /\ c']`, asserting that the
-            // constraints hold at `TO_STEP`
-            let smt_res = query(
-                ctx,
-                smt_ctx,
-                sys,
-                &mut self.enc,
-                vec![
-                    inf_assump,
-                    clause_proxy,
-                    cube_proxy,
-                    self.to_step_constraints_active,
-                    neg_bad,
-                ],
-                false,
-            )?
-            .0;
-
-            // Clean up
-            let neg_clause_proxy = ctx.not(clause_proxy);
-            let neg_cube_proxy = ctx.not(cube_proxy);
-            smt_ctx.assert(ctx, neg_clause_proxy)?;
-            smt_ctx.assert(ctx, neg_cube_proxy)?;
-
-            if smt_res == CheckSatResponse::Unsat {
-                // If UNSAT, blocked cube can also be propagated to infinite frame
-                self.add_blocked_cube(
+                // Run the query `SAT?[R_\infty /\ \neg c /\ T /\ c']`, asserting that the
+                // constraints hold at `TO_STEP`
+                let smt_res = query(
                     ctx,
                     smt_ctx,
-                    TimedCube {
-                        cube,
-                        frame: FrameId::Infinite,
-                    },
-                )?;
-            } else {
-                // Else, blocked cube can only stay in finite frame
-                self[front].cubes.push(cube);
-            }
-        }
+                    sys,
+                    &mut self.enc,
+                    vec![
+                        inf_assump,
+                        clause_proxy,
+                        cube_proxy,
+                        self.to_step_constraints_active,
+                        neg_bad,
+                    ],
+                    false,
+                )?
+                .0;
 
-        // Clean up
-        let neg_inf_proxy = ctx.not(inf_assump);
-        smt_ctx.assert(ctx, neg_inf_proxy)?;
+                if smt_res == CheckSatResponse::Unsat {
+                    // If UNSAT, blocked cube can also be propagated to infinite frame
+                    self.add_blocked_cube(
+                        ctx,
+                        smt_ctx,
+                        TimedCube {
+                            cube,
+                            frame: FrameId::Infinite,
+                        },
+                    )?;
+                } else {
+                    // Else, blocked cube can only stay in finite frame
+                    self[front].cubes.push(cube);
+                }
+            }
+
+            Ok(())
+        })?;
 
         // Inductive invariant not found
         Ok(false)

--- a/patronus/src/mc/pdr.rs
+++ b/patronus/src/mc/pdr.rs
@@ -304,8 +304,8 @@ impl<E: TransitionSystemEncoding> PdrEncodingWrapper<E> {
     /// Step all symbol leaves in SMT expressions
     ///
     /// # Precondition
-    /// All symbols in [expr] must be unstepped, and there must exist a stepped version of each
-    /// symbol at [step] (unrolled in the original [`TransitionSystemEncoding`])
+    /// All symbols in `expr` must be unstepped, and there must exist a stepped version of each
+    /// symbol at `step` (unrolled in the original [`TransitionSystemEncoding`])
     fn expr_at_step(&mut self, ctx: &mut Context, expr: ExprRef, step: Step) -> ExprRef {
         if let Some(&sym) = self.expr_cache.get(&(expr, step)) {
             // If stepped expression already exists in cache, return cached version
@@ -676,7 +676,7 @@ impl BasePdr {
     /// on non-intersection if `get_unsat_core` is true
     ///
     /// # Errors
-    /// Returns [`UnexpectedResponse`] if any SMT query returns `UNKNOWN`
+    /// Returns [`Error::UnexpectedResponse`] if any SMT query returns `UNKNOWN`
     fn intersects_init(
         &mut self,
         ctx: &mut Context,
@@ -812,7 +812,7 @@ impl BasePdr {
     ///
     /// # Returns
     /// Query result and possibly a model for `SAT` cases, or a generalized cube if
-    /// `unsat_core_enabled` is set in [`GLOB_PDR_OPTS`]
+    /// `disable_unsat_cores` is not [`true`]
     fn rel_ind(
         &mut self,
         ctx: &mut Context,
@@ -910,7 +910,7 @@ impl BasePdr {
     /// (i.e. `SAT?[R_N /\ \neg P]`)
     ///
     /// # Returns
-    /// [`Some(Cube)`] with violation, else [`None`]
+    /// `Some(Cube)` with violation, else [`None`]
     ///
     /// # Errors
     /// In cases of `Unknown` SMT queries, return [`Error::UnexpectedResponse`]

--- a/patronus/src/smt/solver.rs
+++ b/patronus/src/smt/solver.rs
@@ -479,12 +479,12 @@ pub const BITWUZLA: SmtLibSolver = SmtLibSolver {
 pub const YICES2: SmtLibSolver = SmtLibSolver {
     name: "yices-smt2",
     args: &["--incremental"],
-    options: &[],
-    supports_uf: false, // actually true, but ignoring for now
-    supports_check_assuming: false,
+    options: &["produce-unsat-assumptions"],
+    supports_uf: false,            // actually true, but ignoring for now
+    supports_check_assuming: true, // only works with Boolean literals
     // see https://github.com/SRI-CSL/yices2/issues/110
     supports_const_array: false,
-    supports_unsat_assumptions: false,
+    supports_unsat_assumptions: true,
 };
 
 pub const Z3: SmtLibSolver = SmtLibSolver {

--- a/patronus/src/smt/solver.rs
+++ b/patronus/src/smt/solver.rs
@@ -85,6 +85,10 @@ pub trait SolverMetaData {
     // properties
     fn name(&self) -> &str;
     fn supports_check_assuming(&self) -> bool;
+    /// Indicates whether `(check-sat-assuming ...)` accepts arbitrary Boolean-valued expressions
+    fn supports_check_assuming_exprs(&self) -> bool {
+        true
+    }
     fn supports_uf(&self) -> bool;
     /// Indicates whether the solver supports the non-standard `(as const)` command.
     fn supports_const_array(&self) -> bool;
@@ -128,6 +132,7 @@ pub struct SmtLibSolver {
     options: &'static [&'static str],
     supports_uf: bool,
     supports_check_assuming: bool,
+    supports_check_assuming_exprs: bool,
     supports_const_array: bool,
     supports_unsat_assumptions: bool,
 }
@@ -139,6 +144,10 @@ impl SolverMetaData for SmtLibSolver {
 
     fn supports_check_assuming(&self) -> bool {
         self.supports_check_assuming
+    }
+
+    fn supports_check_assuming_exprs(&self) -> bool {
+        self.supports_check_assuming_exprs
     }
 
     fn supports_uf(&self) -> bool {
@@ -180,6 +189,7 @@ impl Solver for SmtLibSolver {
             solver_options: self.options.iter().map(|a| a.to_string()).collect(),
             supports_uf: self.supports_uf,
             supports_check_assuming: self.supports_check_assuming,
+            supports_check_assuming_exprs: self.supports_check_assuming_exprs,
             supports_const_array: self.supports_const_array,
             supports_get_unsat_assumptions: self.supports_unsat_assumptions,
             symbols: vec![SymbolTable::default()],
@@ -214,6 +224,7 @@ pub struct SmtLibSolverCtx {
     // solver capabilities
     supports_uf: bool,
     supports_check_assuming: bool,
+    supports_check_assuming_exprs: bool,
     supports_const_array: bool,
     supports_get_unsat_assumptions: bool,
     /// Internal symbol tables for each solver context
@@ -329,6 +340,10 @@ impl SolverMetaData for SmtLibSolverCtx {
     }
     fn supports_check_assuming(&self) -> bool {
         self.supports_check_assuming
+    }
+
+    fn supports_check_assuming_exprs(&self) -> bool {
+        self.supports_check_assuming_exprs
     }
 
     fn supports_const_array(&self) -> bool {
@@ -472,6 +487,7 @@ pub const BITWUZLA: SmtLibSolver = SmtLibSolver {
     options: &["incremental", "produce-models", "produce-unsat-assumptions"],
     supports_uf: false,
     supports_check_assuming: true,
+    supports_check_assuming_exprs: true,
     supports_const_array: true,
     supports_unsat_assumptions: true,
 };
@@ -480,8 +496,9 @@ pub const YICES2: SmtLibSolver = SmtLibSolver {
     name: "yices-smt2",
     args: &["--incremental"],
     options: &["produce-unsat-assumptions"],
-    supports_uf: false,            // actually true, but ignoring for now
-    supports_check_assuming: true, // only works with Boolean literals
+    supports_uf: false,                   // actually true, but ignoring for now
+    supports_check_assuming: true,
+    supports_check_assuming_exprs: false,
     // see https://github.com/SRI-CSL/yices2/issues/110
     supports_const_array: false,
     supports_unsat_assumptions: true,
@@ -498,6 +515,7 @@ pub const Z3: SmtLibSolver = SmtLibSolver {
     options: &["produce-unsat-assumptions"],
     supports_uf: true,
     supports_check_assuming: true,
+    supports_check_assuming_exprs: true,
     supports_const_array: true,
     supports_unsat_assumptions: true,
 };
@@ -508,6 +526,7 @@ pub const CVC5: SmtLibSolver = SmtLibSolver {
     options: &["produce-unsat-assumptions"],
     supports_uf: true,
     supports_check_assuming: true,
+    supports_check_assuming_exprs: true,
     supports_const_array: true,
     supports_unsat_assumptions: true,
 };
@@ -558,7 +577,7 @@ mod tests {
     #[test]
     fn test_check_sat_assuming() {
         let backend = solver_from_env();
-        if !backend.supports_check_assuming() {
+        if !backend.supports_check_assuming() || !backend.supports_check_assuming_exprs() {
             return;
         }
         let mut ctx = Context::default();
@@ -577,7 +596,7 @@ mod tests {
     #[test]
     fn test_unsat_assumptions_basic() {
         let backend = solver_from_env();
-        if !backend.supports_get_unsat_assumptions() {
+        if !backend.supports_get_unsat_assumptions() || !backend.supports_check_assuming_exprs() {
             return;
         }
         let mut ctx = Context::default();
@@ -602,7 +621,7 @@ mod tests {
     #[test]
     fn test_unsat_assumptions_false() {
         let backend = solver_from_env();
-        if !backend.supports_get_unsat_assumptions() {
+        if !backend.supports_get_unsat_assumptions() || !backend.supports_check_assuming_exprs() {
             return;
         }
         let mut ctx = Context::default();
@@ -629,7 +648,7 @@ mod tests {
     #[test]
     fn test_unsat_assumptions_subset() {
         let backend = solver_from_env();
-        if !backend.supports_get_unsat_assumptions() {
+        if !backend.supports_get_unsat_assumptions() || !backend.supports_check_assuming_exprs() {
             return;
         }
         let mut ctx = Context::default();
@@ -693,7 +712,7 @@ mod tests {
     #[test]
     fn test_unsat_assumptions_empty() {
         let backend = solver_from_env();
-        if !backend.supports_get_unsat_assumptions() {
+        if !backend.supports_get_unsat_assumptions() || !backend.supports_check_assuming_exprs() {
             return;
         }
         let mut ctx = Context::default();
@@ -726,7 +745,7 @@ mod tests {
     #[test]
     fn test_push_pop() {
         let backend = solver_from_env();
-        if !backend.supports_get_unsat_assumptions() {
+        if !backend.supports_get_unsat_assumptions() || !backend.supports_check_assuming_exprs() {
             return;
         }
         let mut ctx = Context::default();
@@ -826,7 +845,7 @@ mod tests {
     #[test]
     fn test_unsat_assumptions_fail() {
         let backend = solver_from_env();
-        if !backend.supports_get_unsat_assumptions() {
+        if !backend.supports_get_unsat_assumptions() || !backend.supports_check_assuming_exprs() {
             return;
         }
         let mut ctx = Context::default();

--- a/patronus/src/smt/solver.rs
+++ b/patronus/src/smt/solver.rs
@@ -496,7 +496,7 @@ pub const YICES2: SmtLibSolver = SmtLibSolver {
     name: "yices-smt2",
     args: &["--incremental"],
     options: &["produce-unsat-assumptions"],
-    supports_uf: false,                   // actually true, but ignoring for now
+    supports_uf: false, // actually true, but ignoring for now
     supports_check_assuming: true,
     supports_check_assuming_exprs: false,
     // see https://github.com/SRI-CSL/yices2/issues/110

--- a/patronus/tests/pdr.rs
+++ b/patronus/tests/pdr.rs
@@ -82,7 +82,6 @@ fn run_pdr_str(
 }
 
 /// Run PDR on a BTOR file and possibly return the result if solver is compatible with options
-/// (e.g. YICES2 cannot be run with UNSAT cores enabled)
 fn run_pdr_file(
     solver: &SmtLibSolver,
     btor_file: &str,


### PR DESCRIPTION
# Changes

- Added proxy variables (activation literals) for all compound expression query assumptions in BMC and PDR
- Ensured stale proxy variables are cleaned up
- Extended `(check-sat-assuming)` and `(get-unsat-assumptions)` support for YICES2
- Added new `supports_check_assuming_exprs` flag to mark solvers that can accept compound expression query assumptions 
- Refactored some solver tests to skip if compound query assumptions were required

# Notice

The last two actions items were done with the help of an LLM. All output was reviewed for correctness.