### PR TITLE
Fix bit-slicing index mismatch and Z3 setup issues in CI/CD

### DIFF
--- a/.github/workflows/setup-z3/action.yml
+++ b/.github/workflows/setup-z3/action.yml
@@ -4,6 +4,9 @@ inputs:
   version:
     description: version to install
     required: true
+  glibc_version:
+    description: glibc version of the release archive
+    required: true
 
 runs:
   using: composite
@@ -12,7 +15,7 @@ runs:
       id: cache-z3
       uses: actions/cache@v5
       with:
-        key: z3-${{ runner.os }}-${{ inputs.version }}
+        key: z3-${{ runner.os }}-${{ inputs.version }}-glibc-${{ inputs.glibc_version }}
         path: /tmp/z3
     - name: Download Z3
       shell: sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,7 @@ jobs:
       uses: ./.github/workflows/setup-z3
       with:
         version: ${{ env.Z3_VERSION }}
+        glibc_version: ${{ env.GLIBC_VERSION }}
     - name: Set Up CVC5
       if: ${{ matrix.solver == 'cvc5' }}
       uses: ./.github/workflows/setup-cvc5
@@ -81,6 +82,7 @@ jobs:
         uses: ./.github/workflows/setup-z3
         with:
           version: ${{ env.Z3_VERSION }}
+          glibc_version: ${{ env.GLIBC_VERSION }}
       - name: Set Up CVC5
         if: ${{ matrix.solver == 'cvc5' }}
         uses: ./.github/workflows/setup-cvc5

--- a/patronus/src/expr/simplify.rs
+++ b/patronus/src/expr/simplify.rs
@@ -562,9 +562,16 @@ fn simplify_bv_slice(ctx: &mut Context, e: ExprRef, hi: WidthInt, lo: WidthInt) 
         // slice of sign extend
         Expr::BVSignExt { e, .. } => {
             let e_width = e.get_bv_type(ctx).unwrap();
-            if hi < e_width {
+
+            if lo >= e_width {
+                // Slice exists in extended bits (just get sign bits)
+                let sign_bit = ctx.slice(e, e_width - 1, e_width - 1);
+                Some(ctx.sign_extend(sign_bit, hi - lo))
+            } else if hi < e_width {
+                // Slice exists in original bits only
                 Some(ctx.slice(e, hi, lo))
             } else {
+                // Slice straddles original and extended bits
                 let inner = ctx.slice(e, e_width - 1, lo);
                 Some(ctx.sign_extend(inner, hi - e_width + 1))
             }

--- a/patronus/tests/simplify.rs
+++ b/patronus/tests/simplify.rs
@@ -411,6 +411,8 @@ fn test_simplify_slice_on_sign_extension() {
     ts("sext(a:bv<4>, 2)[4:0]", "sext(a:bv<4>, 1)");
     ts("sext(a:bv<4>, 2)[5:0]", "sext(a:bv<4>, 2)");
     ts("sext(a:bv<4>, 2)[4:1]", "sext(a:bv<4>[3:1], 1)");
+    ts("sext(a:bv<4>, 32)[31:31]", "a:bv<4>[3:3]");
+    ts("sext(a:bv<4>, 32)[31:28]", "sext(a:bv<4>[3:3], 3)");
 }
 
 #[test]


### PR DESCRIPTION
# Changes

- Previous simplifier for bit-vector sign extension assumed that bit slices in sign-extended bit-vectors were always in the original bits or straddling the original and extended bits. However, if the bit slice was only in the extended bits, the bit ranges for the bit slice would be lopsided, leading to a panic. To fix this, a new case was added to account for bit slices purely in the extended bits (by just spreading the sign bit of the original bits for the width of the bit slice).
- Updated Z3 setup in CI